### PR TITLE
Working install v0.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+ansible = "*"
+ansible-lint = "*"
+jmespath = "*"
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,479 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "56458ea9a86643be5fc84d74d39d23a26d4f14e377eb2cd5588816d92943dc29"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "ansible": {
+            "hashes": [
+                "sha256:20625109c4e9c79e9e23bff6d1e32a780d13935007369111261a7ddfd3cf75b1",
+                "sha256:bdaf2b2fd926ff189fbde2fefe7234733f32c36fc413033fa5d93945fbdc06a6"
+            ],
+            "index": "pypi",
+            "version": "==6.2.0"
+        },
+        "ansible-compat": {
+            "hashes": [
+                "sha256:676db8ec0449d1f07038625b8ebb8ceef5f8ad3a1af3ee82d4ed66b9b04cb6fa",
+                "sha256:ce69a67785ae96e8962794a47494339991a0ae242ab5dd14a76ee2137d09072e"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
+        },
+        "ansible-core": {
+            "hashes": [
+                "sha256:331b869cf3bf9bab875f62b9a8586257bbcfb95b1db6c8d43424d70804996143",
+                "sha256:b779d0e55a97717c0ee5e86b486aa67c07c2809ef477be2ac84ad091a8dd2ddb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.13.2"
+        },
+        "ansible-lint": {
+            "hashes": [
+                "sha256:bea12b88a69c1f9a6746ec0532aa72d6e7ca44918eea9a8110bc321b208f49e7",
+                "sha256:c5a76306cae906a260cf7286ca87c4d03ba4492b2ed7bfea21ad11fdf3c7e8d1"
+            ],
+            "index": "pypi",
+            "version": "==6.4.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
+        },
+        "bracex": {
+            "hashes": [
+                "sha256:351b7f20d56fb9ea91f9b9e9e7664db466eb234188c175fd943f8f755c807e73",
+                "sha256:e7b23fc8b2cd06d3dec0692baabecb249dda94e06a617901ff03a6c56fd71693"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.3.post1"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
+                "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
+                "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
+                "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
+                "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
+                "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
+                "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
+                "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
+                "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
+                "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
+                "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+                "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
+                "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+                "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
+                "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
+                "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
+                "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+                "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
+                "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
+                "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
+                "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
+                "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
+                "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
+                "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2",
+                "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
+                "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
+                "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+                "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
+                "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
+                "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+                "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
+                "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
+                "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
+                "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
+                "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
+                "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
+                "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
+                "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
+                "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
+                "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
+                "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
+                "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
+                "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
+                "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
+                "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
+                "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
+                "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
+                "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
+                "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
+                "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
+                "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
+                "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
+                "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
+                "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
+                "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
+                "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
+                "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
+                "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
+                "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
+                "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
+                "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
+                "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
+                "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
+                "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"
+            ],
+            "version": "==1.15.1"
+        },
+        "commonmark": {
+            "hashes": [
+                "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60",
+                "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"
+            ],
+            "version": "==0.9.1"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59",
+                "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596",
+                "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3",
+                "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5",
+                "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab",
+                "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884",
+                "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82",
+                "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b",
+                "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441",
+                "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa",
+                "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d",
+                "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b",
+                "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a",
+                "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6",
+                "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157",
+                "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280",
+                "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282",
+                "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67",
+                "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8",
+                "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046",
+                "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327",
+                "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==37.0.4"
+        },
+        "enrich": {
+            "hashes": [
+                "sha256:0a2ab0d2931dff8947012602d1234d2a3ee002d9a355b5d70be6bf5466008893",
+                "sha256:f29b2c8c124b4dbd7c975ab5c3568f6c7a47938ea3b7d2106c8a3bd346545e4f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.7"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.2"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "index": "pypi",
+            "version": "==1.0.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:408c4c8ed0dede3b268f7a441784f74206380b04f93eb2d537c7befb3df3099f",
+                "sha256:8ebad55894c002585271af2d327d99339ef566fb085d9129b69e2623867c4106"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.9.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
+                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+            ],
+            "version": "==2.21"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
+                "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.12.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c",
+                "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc",
+                "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e",
+                "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26",
+                "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec",
+                "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286",
+                "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045",
+                "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec",
+                "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8",
+                "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c",
+                "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca",
+                "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22",
+                "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a",
+                "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96",
+                "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc",
+                "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1",
+                "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07",
+                "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6",
+                "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b",
+                "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5",
+                "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.18.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
+                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==7.1.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
+                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
+                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
+                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
+                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
+                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
+                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
+                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
+                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
+                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
+                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
+                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
+                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
+                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
+                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
+                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
+                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
+                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
+                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
+                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
+                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
+                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.0"
+        },
+        "resolvelib": {
+            "hashes": [
+                "sha256:c6ea56732e9fb6fca1b2acc2ccc68a0b6b8c566d8f3e78e0443310ede61dbd37",
+                "sha256:d9b7907f055c3b3a2cfc56c914ffd940122915826ff5fb5b1de0c99778f4de98"
+            ],
+            "version": "==0.8.1"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb",
+                "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"
+            ],
+            "markers": "python_full_version >= '3.6.3' and python_full_version < '4.0.0'",
+            "version": "==12.5.1"
+        },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7",
+                "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==0.17.21"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd",
+                "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee",
+                "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0",
+                "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7",
+                "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277",
+                "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104",
+                "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd",
+                "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0",
+                "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78",
+                "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de",
+                "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99",
+                "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527",
+                "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84",
+                "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7",
+                "sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468",
+                "sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b",
+                "sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94",
+                "sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233",
+                "sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb",
+                "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5",
+                "sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe",
+                "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751",
+                "sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502",
+                "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
+                "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
+            ],
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.11'",
+            "version": "==0.2.6"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:63f463b90ff5e0a1422010100268fd688e15c44ae0798659013c8412963e15e4",
+                "sha256:9b5d2cb8df48f005825654e0cb17217418317e4d996c035f0bca7cbaeb8acf51"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==64.0.0"
+        },
+        "subprocess-tee": {
+            "hashes": [
+                "sha256:d34186c639aa7f8013b5dfba80e17f52589539137c9d9205f2ae1c1bd03549e1",
+                "sha256:ff5cced589a4b8ac973276ca1ba21bb6e3de600cde11a69947ff51f696efd577"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.3.5"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
+        },
+        "wcmatch": {
+            "hashes": [
+                "sha256:ba4fc5558f8946bf1ffc7034b05b814d825d694112499c86035e0e4d398b6a67",
+                "sha256:dc7351e5a7f8bbf4c6828d51ad20c1770113f5f3fd3dfe2a03cfde2a63f03f98"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.4"
+        },
+        "yamllint": {
+            "hashes": [
+                "sha256:e688324b58560ab68a1a3cff2c0a474e3fed371dfe8da5d1b9817b7df55039ce"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.27.1"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ### :warning: THIS REPO IS UNTESTED! Ansible is not currently supported by paperless-ngx. Use only at your own peril. :warning:
 
-Ansible Role: paperless-ng
-==========================
+Ansible Role: paperless-ngx
+===========================
 
-Installs and configures paperless-ng EDMS on Debian/Ubuntu systems.
+Installs and configures paperless-ngx EDMS on Debian/Ubuntu systems.
 
 Requirements
 ------------
@@ -11,82 +11,82 @@ Requirements
 No special system requirements. Ansible 2.7 or newer is required.
 
 Note that this role requires root access, so either run it in a playbook with a global `become: yes`, or invoke the role in your playbook like:
+```
+- hosts: all
+  roles:
+  - role: paperless-ngx
+    become: yes
+    Role Variables
+```
+---
 
-    - hosts: all
-      roles:
-        - role: paperless-ng
-          become: yes
-
-Role Variables
---------------
-
-Most configuration variables from paperless-ng itself are available and accept their respective arguments.
+Most configuration variables from paperless-ngx itself are available and accept their respective arguments.
 Every `PAPERLESS_*` configuration variable is lowercased and instead prefixed with `paperlessng_*` in `defaults/main.yml`.
 
-For a full listing including explanations and allowed values, see the current [documentation](https://paperless-ng.readthedocs.io/en/latest/configuration.html).
+For a full listing including explanations and allowed values, see the current [documentation](https://paperless-ngx.readthedocs.io/en/latest/configuration.html).
+
+
 
 Additional variables available in this role are listed below, along with default values:
-
-    paperlessng_version: latest
-
-The [release](https://github.com/jonaswinkler/paperless-ng/releases) archive version of paperless-ng to install.
-`latest` stands for the latest release of paperless-ng.
-To install a specific version of paperless-ng, use the tag name of the release, e. g. `ng-1.4.4`, or specify a branch or commit id.
-
-    paperlessng_redis_host: localhost
-    paperlessng_redis_port: 6379
-
+```paperlessng_version: latest```
+The [release](https://github.com/paperless-ngx/paperless-ngx/releases) archive version of paperless-ngx to install.
+`latest` stands for the latest release of paperless-ngx.
+To install a specific version of paperless-ngx, use the tag name of the release, e. g. `1.4.4` when the tag is `ngx-1.4.4`.
+```
+paperlessng_redis_host: localhost
+paperlessng_redis_port: 6379
+```
 Separate configuration values that combine into `PAPERLESS_REDIS`.
-
-    paperlessng_db_type: sqlite
-
+```
+paperlessng_db_type: sqlite
+```
 Database to use. Default is file-based SQLite.
-
-    paperlessng_db_host: localhost
-    paperlessng_db_port: 5432
-    paperlessng_db_name: paperlessng
-    paperlessng_db_user: paperlessng
-    paperlessng_db_pass: paperlessng
-    paperlessng_db_sslmode: prefer
-
+```
+paperlessng_db_host: localhost
+paperlessng_db_port: 5432
+paperlessng_db_name: paperlessng
+paperlessng_db_user: paperlessng
+paperlessng_db_pass: paperlessng
+paperlessng_db_sslmode: prefer
+```
 Database configuration (only applicable if `paperlessng_db_type == 'postgresql'`).
-
-    paperlessng_directory: /opt/paperless-ng
-
-Root directory paperless-ng is installed into.
-
-    paperlessng_virtualenv: "{{ paperlessng_directory }}/.venv"
-
-Directory used for the virtual environment for paperless-ng.
-
-    paperlessng_ocr_languages:
-      - eng
-
+```
+paperlessng_directory: /opt/paperless-ngx
+```
+Root directory paperless-ngx is installed into.
+```
+paperlessng_virtualenv: "{{ paperlessng_directory }}/.venv"
+```
+Directory used for the virtual environment for paperless-ngx.
+```
+paperlessng_ocr_languages:
+- eng
+```
 List of OCR languages to install and configure (`apt search tesseract-ocr-*`).
-
-    paperlessng_use_jbig2enc: True
-
+```
+paperlessng_use_jbig2enc: True
+```
 Whether to install and use [jbig2enc](https://github.com/agl/jbig2enc) for OCRmyPDF.
-
-    paperlessng_big2enc_lossy: False
-
+```
+paperlessng_big2enc_lossy: False
+```
 Whether to use jbig2enc's lossy compression mode.
-
-    paperlessng_superuser_name: paperlessng
-    paperlessng_superuser_email: paperlessng@example.com
-    paperlessng_superuser_password: paperlessng
-
-Credentials of the initial superuser in paperless-ng.
-
-    paperlessng_system_user: paperlessng
-    paperlessng_system_group: paperlessng
-
-System user and group to run the paperless-ng services as (will be created if required).
-
-    paperlessng_listen_address: 127.0.0.1
-    paperlessng_listen_port: 8000
-
-Address and port for the paperless-ng service to listen on.
+```
+paperlessng_superuser_name: paperlessng
+paperlessng_superuser_email: paperlessng@example.com
+paperlessng_superuser_password: paperlessng
+```
+Credentials of the initial superuser in paperless-ngx.
+```
+paperlessng_system_user: paperlessng
+paperlessng_system_group: paperlessng
+```
+System user and group to run the paperless-ngx services as (will be created if required).
+```
+paperlessng_listen_address: 127.0.0.1
+paperlessng_listen_port: 8000
+```
+Address and port for the paperless-ngx service to listen on.
 
 Dependencies
 ------------
@@ -95,24 +95,39 @@ No ansible dependencies.
 
 Example Playbook
 ----------------
+
 `playbook.yml`:
 
-    - hosts: all
-      become: yes
-      vars_files:
-        - vars/paperless-ng.yml
-      roles:
-        - paperless-ng
+```
+- hosts: all
+    become: yes
+    roles:
+        - { role: ansible-paperless-ngx,  tags: ["paperless"] }
+    vars:
+        paperlessng_version: 1.6.0
+        paperlessng_install_method: precompiledrelease
+        paperlessng_use_jbig2enc: true
+        paperlessng_secret_key: mxsupersecurekeyforhashing
+        paperlessng_data_dir: "/paperlessdata/data"
+        paperlessng_trash_dir: "/paperlessdata/trash"
+        paperlessng_consumption_dir: "/paperlessdata/consumption"
+        paperlessng_media_root: "/paperlessdata/media"
+        paperlessng_ocr_languages:
+        - deu
+        - eng
+        paperlessng_ocr_mode: skip
+        paperlessng_time_zone: Europe/Berlin
+        paperlessng_consumer_recursive: true
+        paperlessng_superuser_name: superuser
+        paperlessng_superuser_email: mymail@mydomain.local
+        paperlessng_superuser_password: supersecurepasswordchangeme
+        paperlessng_listen_address: 0.0.0.0
+        paperlessng_listen_port: 8000
+```
 
-`vars/paperless-ng.yml`:
+Additional:
 
-    paperlessng_media_root: /mnt/media/smbshare
-
-    paperlessng_db_type: postgresql
-    paperlessng_db_pass: PLEASEPROVIDEASTRONGPASSWORDHERE
-
-    paperlessng_secret_key: AGAINPLEASECHANGETHISNOW
-
-    paperlessng_ocr_languages:
-      - eng
-      - deu
+```
+paperlessng_db_type: postgresql
+paperlessng_db_pass: PLEASEPROVIDEASTRONGPASSWORDHERE
+```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To install a specific version of paperless-ngx, use the tag name of the release,
 Dependencies
 ------------
 
-No ansible dependencies.
+There is a dependency on `jmespath`. This is included as part of the community.general collection within ansible. Please follow this link for more information - https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#selecting-json-data-json-queries
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-### :warning: THIS REPO IS UNTESTED! Ansible is not currently supported by paperless-ngx. Use only at your own peril. :warning:
-
 Ansible Role: paperless-ngx
 ===========================
 
@@ -16,8 +14,8 @@ Note that this role requires root access, so either run it in a playbook with a 
   roles:
   - role: paperless-ngx
     become: yes
-    Role Variables
 ```
+Role Variables
 ---
 
 Most configuration variables from paperless-ngx itself are available and accept their respective arguments.
@@ -29,64 +27,35 @@ For a full listing including explanations and allowed values, see the current [d
 
 Additional variables available in this role are listed below, along with default values:
 ```paperlessng_version: latest```
-The [release](https://github.com/paperless-ngx/paperless-ngx/releases) archive version of paperless-ngx to install.
-`latest` stands for the latest release of paperless-ngx.
-To install a specific version of paperless-ngx, use the tag name of the release, e. g. `1.4.4` when the tag is `ngx-1.4.4`.
-```
-paperlessng_redis_host: localhost
-paperlessng_redis_port: 6379
-```
-Separate configuration values that combine into `PAPERLESS_REDIS`.
-```
-paperlessng_db_type: sqlite
-```
-Database to use. Default is file-based SQLite.
-```
-paperlessng_db_host: localhost
-paperlessng_db_port: 5432
-paperlessng_db_name: paperlessng
-paperlessng_db_user: paperlessng
-paperlessng_db_pass: paperlessng
-paperlessng_db_sslmode: prefer
-```
-Database configuration (only applicable if `paperlessng_db_type == 'postgresql'`).
-```
-paperlessng_directory: /opt/paperless-ngx
-```
-Root directory paperless-ngx is installed into.
-```
-paperlessng_virtualenv: "{{ paperlessng_directory }}/.venv"
-```
-Directory used for the virtual environment for paperless-ngx.
-```
-paperlessng_ocr_languages:
-- eng
-```
-List of OCR languages to install and configure (`apt search tesseract-ocr-*`).
-```
-paperlessng_use_jbig2enc: True
-```
-Whether to install and use [jbig2enc](https://github.com/agl/jbig2enc) for OCRmyPDF.
-```
-paperlessng_big2enc_lossy: False
-```
-Whether to use jbig2enc's lossy compression mode.
-```
-paperlessng_superuser_name: paperlessng
-paperlessng_superuser_email: paperlessng@example.com
-paperlessng_superuser_password: paperlessng
-```
-Credentials of the initial superuser in paperless-ngx.
-```
-paperlessng_system_user: paperlessng
-paperlessng_system_group: paperlessng
-```
-System user and group to run the paperless-ngx services as (will be created if required).
-```
-paperlessng_listen_address: 127.0.0.1
-paperlessng_listen_port: 8000
-```
-Address and port for the paperless-ngx service to listen on.
+
+The [release](https://github.com/paperless-ngx/paperless-ngx/releases) archive version of paperless-ngx to install. `latest` stands for the latest release of paperless-ngx.
+
+To install a specific version of paperless-ngx, use the tag name of the release, e. g. `v1.8.0`
+
+| Additional Variables           | Required/Optional | Example Value                       | Description                                                                      |
+|--------------------------------|-------------------|-------------------------------------|----------------------------------------------------------------------------------|
+| paperlessng_version            | Required          | v1.8.0                              | Version to install                                                               |
+| paperlessng_redis_host         | Required          | localhost                           | Separate configuration values that combine into PAPERLESS_REDIS.                 |
+| paperlessng_redis_port         | Required          | 6379                                | Separate configuration values that combine into PAPERLESS_REDIS.                 |
+| paperlessng_db_type            | Required          | sqlite                              | Database to use. Default is file-based SQLite..                                  |
+| paperlessng_db_host            | Optional          | localhost                           | Database configuration **(only applicable if paperlessng_db_type == 'postgresql').** |
+| paperlessng_db_port            | Optional          | 5432                                | Database configuration **(only applicable if paperlessng_db_type == 'postgresql').** . |
+| paperlessng_db_name            | Optional          | paperlessng                         | Database configuration **(only applicable if paperlessng_db_type == 'postgresql').**  |
+| paperlessng_db_user            | Optional          | paperlessng                         | Database configuration **(only applicable if paperlessng_db_type == 'postgresql').**  |
+| paperlessng_db_pass            | Optional          | paperlessng                         | Database configuration **(only applicable if paperlessng_db_type == 'postgresql').**  |
+| paperlessng_db_sslmode         | Optional          | prefer                              | Database configuration **(only applicable if paperlessng_db_type == 'postgresql').**  |
+| paperlessng_directory          | Required          | /opt/paperless-ngx                  | Root directory paperless-ngx is installed into.                                  |
+| paperlessng_virtualenv         | Required          | "{{ paperlessng_directory }}/.venv" | Directory used for the virtual environment for paperless-ngx                     |
+| paperlessng_ocr_languages      | Required          | eng                                 | List of OCR languages to install and configure (`apt search tesseract-ocr-*`).   |
+| paperlessng_use_jbig2enc       | Optional          | True                                | Whether to install and use jbig2enc for OCRmyPDF                                 |
+| paperlessng_big2enc_lossy      | Optional          | False                               | Whether to use jbig2enc's lossy compression mode                                 |
+| paperlessng_superuser_name     | Required          | paperlessng                         | Credentials of the initial superuser in paperless-ngx.                           |
+| paperlessng_superuser_email    | Required          | paperlessng@example.com             | Credentials of the initial superuser in paperless-ngx.                           |
+| paperlessng_superuser_password | Required          | paperlessng                         | Credentials of the initial superuser in paperless-ngx.                           |
+| paperlessng_system_user        | Required          | paperlessng                         | System user to run the paperless-ngx services as (will be created if required).  |
+| paperlessng_system_group       | Required          | paperlessng                         | System group to run the paperless-ngx services as (will be created if required). |
+| paperlessng_listen_address     | Required          | 127.0.0.1                           | Address for the paperless-ngx service to listen on.                              |
+| paperlessng_listen_port        | Required          | 8000                                | Port for the paperless-ngx service to listen on.                                 |
 
 Dependencies
 ------------
@@ -104,7 +73,7 @@ Example Playbook
     roles:
         - { role: ansible-paperless-ngx,  tags: ["paperless"] }
     vars:
-        paperlessng_version: 1.6.0
+        paperlessng_version: v1.8.0
         paperlessng_install_method: precompiledrelease
         paperlessng_use_jbig2enc: true
         paperlessng_secret_key: mxsupersecurekeyforhashing
@@ -123,11 +92,4 @@ Example Playbook
         paperlessng_superuser_password: supersecurepasswordchangeme
         paperlessng_listen_address: 0.0.0.0
         paperlessng_listen_port: 8000
-```
-
-Additional:
-
-```
-paperlessng_db_type: postgresql
-paperlessng_db_pass: PLEASEPROVIDEASTRONGPASSWORDHERE
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 paperlessng_install_method: precompiledrelease # if you want to build it from src, use 'source'
                                                # or it will try to download the version from github releases with 'precompiledrelease'
-paperlessng_version: latest  # 'latest', release number, or github branch/tag/commit/ref
+paperlessng_version: v1.8.0  # 'latest', release number, or github branch/tag/commit/ref
 
 # Required services
 paperlessng_redis_host: localhost
@@ -20,7 +20,7 @@ paperlessng_directory: /opt/paperless-ngx
 paperlessng_consumption_dir: "{{ paperlessng_directory }}/consumption"
 paperlessng_export_dir: "{{ paperlessng_directory }}/export"
 paperlessng_data_dir: "{{ paperlessng_directory }}/data"
-paperlessng_trash_dir:
+paperlessng_trash_dir: "{{ paperlessng_directory }}/trash"
 paperlessng_media_root: "{{ paperlessng_directory }}/media"
 paperlessng_staticdir: "{{ paperlessng_directory }}/static"
 paperlessng_filename_format:
@@ -35,6 +35,7 @@ paperlessng_consumption_dir_permission:
 paperlessng_consumption_dir_myopts:
 
 # Hosting & Security
+paperlessng_url: "http://change-to-ip-of-host:8000" 
 paperlessng_secret_key: PLEASECHANGETHISFORTHELOVEOFGOD
 paperlessng_allowed_hosts: "*"
 paperlessng_cors_allowed_hosts: http://localhost:8000
@@ -91,5 +92,8 @@ paperlessng_system_user: paperlessng
 paperlessng_system_group: paperlessng
 
 # Webserver settings
-paperlessng_listen_address: 127.0.0.1
+paperlessng_listen_address: 0.0.0.0
 paperlessng_listen_port: 8000
+
+# Extra
+paperlessng_enable_update_check: enable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 paperlessng_install_method: precompiledrelease # if you want to build it from src, use 'source'
-                                               # or it will try to download the version from github releases with 'precompiledrelease'
-paperlessng_version: v1.8.0  # 'latest', release number, or github branch/tag/commit/ref
+# or it will try to download the version from github releases with 'precompiledrelease'
+paperlessng_version: v1.8.0 # 'latest', release number, or github branch/tag/commit/ref
 
 # Required services
 paperlessng_redis_host: localhost
@@ -28,14 +28,13 @@ paperlessng_logging_dir: "{{ paperlessng_data_dir }}/log"
 paperlessng_virtualenv: "{{ paperlessng_directory }}/.venv"
 
 #NFS
-paperlessng_consumption_dir_nfs_enabled: False
+paperlessng_consumption_dir_nfs_enabled: false
 paperlessng_consumption_dir_nfs:
 paperlessng_consumption_dir_mountpoint:
 paperlessng_consumption_dir_permission:
 paperlessng_consumption_dir_myopts:
-
 # Hosting & Security
-paperlessng_url: "http://change-to-ip-of-host:8000" 
+paperlessng_url: http://change-to-ip-of-host:8000
 paperlessng_secret_key: PLEASECHANGETHISFORTHELOVEOFGOD
 paperlessng_allowed_hosts: "*"
 paperlessng_cors_allowed_hosts: http://localhost:8000
@@ -43,39 +42,39 @@ paperlessng_force_script_name:
 paperlessng_static_url: /static/
 paperlessng_auto_login_username:
 paperlessng_cookie_prefix: ""
-paperlessng_enable_http_remote_user: False
+paperlessng_enable_http_remote_user: false
 
 # OCR settings
 paperlessng_ocr_languages:
   - eng
 paperlessng_ocr_mode: skip
 paperlessng_ocr_clean: clean
-paperlessng_ocr_deskew: True
-paperlessng_ocr_rotate_pages: True
+paperlessng_ocr_deskew: true
+paperlessng_ocr_rotate_pages: true
 paperlessng_ocr_rotate_pages_threshold: 12
 paperlessng_ocr_output_type: pdfa
 paperlessng_ocr_pages: 0
 paperlessng_ocr_image_dpi:
 # see https://ocrmypdf.readthedocs.io/en/latest/api.html#ocrmypdf.ocr
 paperlessng_ocr_user_args:
-  - "optimize": 1
-paperlessng_use_jbig2enc: True
-paperlessng_big2enc_lossy: False
+  - optimize: 1
+paperlessng_use_jbig2enc: true
+paperlessng_big2enc_lossy: false
 
 # Tika settings
-paperlessng_tika_enabled: False
+paperlessng_tika_enabled: false
 paperlessng_tika_endpoint: http://localhost:9998
 paperlessng_tika_gotenberg_endpoint: http://localhost:3000
 
 # Software tweaks
 paperlessng_time_zone: Europe/London
 paperlessng_consumer_polling: 0
-paperlessng_consumer_delete_duplicates: False
-paperlessng_consumer_recursive: False
-paperlessng_consumer_subdirs_as_tags: False
+paperlessng_consumer_delete_duplicates: false
+paperlessng_consumer_recursive: false
+paperlessng_consumer_subdirs_as_tags: false
 paperlessng_convert_memory_limit: 0
 paperlessng_convert_tmpdir:
-paperlessng_optimize_thumbnails: True
+paperlessng_optimize_thumbnails: true
 paperlessng_pre_consume_script:
 paperlessng_post_consume_script:
 paperlessng_filename_date_order:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+paperlessng_install_method: precompiledrelease # if you want to build it from src, use 'source'
+                                               # or it will try to download the version from github releases with 'precompiledrelease'
 paperlessng_version: latest  # 'latest', release number, or github branch/tag/commit/ref
 
 # Required services
@@ -14,8 +16,9 @@ paperlessng_db_pass: paperlessng
 paperlessng_db_sslmode: prefer
 
 # Paths and folders
-paperlessng_directory: /opt/paperless-ng
+paperlessng_directory: /opt/paperless-ngx
 paperlessng_consumption_dir: "{{ paperlessng_directory }}/consumption"
+paperlessng_export_dir: "{{ paperlessng_directory }}/export"
 paperlessng_data_dir: "{{ paperlessng_directory }}/data"
 paperlessng_trash_dir:
 paperlessng_media_root: "{{ paperlessng_directory }}/media"
@@ -23,6 +26,13 @@ paperlessng_staticdir: "{{ paperlessng_directory }}/static"
 paperlessng_filename_format:
 paperlessng_logging_dir: "{{ paperlessng_data_dir }}/log"
 paperlessng_virtualenv: "{{ paperlessng_directory }}/.venv"
+
+#NFS
+paperlessng_consumption_dir_nfs_enabled: False
+paperlessng_consumption_dir_nfs:
+paperlessng_consumption_dir_mountpoint:
+paperlessng_consumption_dir_permission:
+paperlessng_consumption_dir_myopts:
 
 # Hosting & Security
 paperlessng_secret_key: PLEASECHANGETHISFORTHELOVEOFGOD
@@ -57,7 +67,7 @@ paperlessng_tika_endpoint: http://localhost:9998
 paperlessng_tika_gotenberg_endpoint: http://localhost:3000
 
 # Software tweaks
-paperlessng_time_zone: Europe/Berlin
+paperlessng_time_zone: Europe/London
 paperlessng_consumer_polling: 0
 paperlessng_consumer_delete_duplicates: False
 paperlessng_consumer_recursive: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
+---
 dependencies: []
-
 galaxy_info:
   author: C0nsultant
   description: Bare-metal deployment of paperless-ngx DMS

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ dependencies: []
 
 galaxy_info:
   author: C0nsultant
-  description: Bare-metal deployment of paperless-ng DMS
+  description: Bare-metal deployment of paperless-ngx DMS
   license: license (GPLv3)
   min_ansible_version: 2.7
   namespace: paperless_ng

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,6 +5,6 @@
     - name: set current github commit as version when available
       set_fact:
         paperlessng_version: "{{ lookup('env', 'TARGET_GITHUB_SHA') | default('master', True) }}"
-    - name: update to newest paperless-ng release
+    - name: update to newest paperless-ngx release
       include_role:
         name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ platforms:
       - /tmp
       - /run
       - /run/lock
-    override_command: False
+    override_command: false
   # ubuntu 18.04 bionic works except that
   #   the default redis configuration expects IPv6 which is not enabled in docker by default
   #   the default Python environment is configured for ASCII instead of UTF-8
@@ -27,8 +27,8 @@ platforms:
       - /tmp
       - /run
       - /run/lock
-    override_command: False
-  # debian 9 stretch only has Python 3.5 which is EOL and breaks multiple dependencies
+    override_command: false
+# debian 9 stretch only has Python 3.5 which is EOL and breaks multiple dependencies
 provisioner:
   name: ansible
 verifier:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,3 +1,4 @@
+---
 - name: install previous release
   hosts: all
   tasks:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,6 +5,6 @@
       set_fact:
         paperlessng_version: latest
 
-    - name: install previous paperless-ng release
+    - name: install previous paperless-ngx release
       include_role:
         name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -9,9 +9,9 @@
   tasks:
     - name: check if webserver is up
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}
         status_code: [200, 302]
-        return_content: yes
+        return_content: true
       register: landingpage
       failed_when: "'Sign in</button>' not in landingpage.content"
 
@@ -22,7 +22,7 @@
 
     - name: check if document posting works
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/post_document/"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/post_document/
         method: POST
         body_format: form-multipart
         body:
@@ -30,20 +30,20 @@
             content: "{{ content }}"
             filename: "{{ filename }}.txt"
         headers:
-          Authorization: 'Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}'
+          Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
           Content-Type: text/plain
-        return_content: yes
+        return_content: true
       register: post_document
       failed_when: "'OK' not in post_document.content"
 
     - name: verify uploaded document has been accepted
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/logs/paperless/"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/logs/paperless/
         headers:
-          Authorization: 'Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}'
-        return_content: yes
+          Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
+        return_content: true
       register: logs
-      failed_when: "('Consuming ' + filename + '.txt') not in logs.content"
+      failed_when: ('Consuming ' + filename + '.txt') not in logs.content
 
     - name: sleep till consumption finished
       pause:
@@ -51,19 +51,19 @@
 
     - name: verify uploaded document has been consumed
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/logs/paperless/"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/logs/paperless/
         headers:
-          Authorization: 'Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}'
-        return_content: yes
+          Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
+        return_content: true
       register: logs
-      failed_when: "filename + ' consumption finished' not in logs.content"
+      failed_when: filename + ' consumption finished' not in logs.content
 
     - name: get documents
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/
         headers:
-          Authorization: 'Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}'
-        return_content: yes
+          Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
+        return_content: true
       register: documents
 
     - name: set document index
@@ -72,16 +72,16 @@
 
     - name: verify uploaded document is avaiable
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/{{ index }}/"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/{{ index }}/
         headers:
-          Authorization: 'Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}'
-        return_content: yes
+          Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
+        return_content: true
       register: document
       failed_when: "'Not found.' in document.content or content not in document.json['content']"
 
     - name: check if deleting uploaded document works
       uri:
-        url: "http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/bulk_edit/"
+        url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/bulk_edit/
         method: POST
         body_format: json
         body:
@@ -89,6 +89,6 @@
           method: delete
           parameters: {}
         headers:
-          Authorization: 'Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}'
+          Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
       register: delete_document
       failed_when: "'OK' not in delete_document.json['result']"

--- a/tasks/install-release.yml
+++ b/tasks/install-release.yml
@@ -1,6 +1,6 @@
 ---
-- name: extract paperless-ng
+- name: download and extract paperless-ngx
   unarchive:
-    src: "https://github.com/jonaswinkler/paperless-ng/releases/download/ng-{{ paperlessng_version }}/paperless-ng-{{ paperlessng_version }}.tar.xz"
+    src: "https://github.com/paperless-ngx/paperless-ngx/releases/download/{{ paperlessng_version }}/paperless-ngx-{{ paperlessng_version }}.tar.xz"
     remote_src: yes
     dest: "{{ tempdir.path }}"

--- a/tasks/install-release.yml
+++ b/tasks/install-release.yml
@@ -1,6 +1,6 @@
 ---
 - name: download and extract paperless-ngx
-  unarchive:
-    src: "https://github.com/paperless-ngx/paperless-ngx/releases/download/{{ paperlessng_version }}/paperless-ngx-{{ paperlessng_version }}.tar.xz"
-    remote_src: yes
+  ansible.builtin.unarchive:
+    src: https://github.com/paperless-ngx/paperless-ngx/releases/download/{{ paperlessng_version }}/paperless-ngx-{{ paperlessng_version }}.tar.xz
+    remote_src: true
     dest: "{{ tempdir.path }}"

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -14,8 +14,8 @@
     group: "{{ paperlessng_system_group }}"
     mode: "750"
   with_items:
-    - "{{ tempdir.path }}/paperless-ng"
-    - "{{ tempdir.path }}/paperless-ng/scripts"
+    - "{{ tempdir.path }}/paperless-ngx"
+    - "{{ tempdir.path }}/paperless-ngx/scripts"
 
 - block:
     - name: create temporary git directory
@@ -24,7 +24,7 @@
         path: "{{ paperlessng_directory }}"
       register: gitdir
 
-    - name: pull paperless-ng
+    - name: pull paperless-ngx
       git:
         repo: https://github.com/paperless-ngx/paperless-ngx.git
         dest: "{{ gitdir.path }}"
@@ -46,7 +46,7 @@
       copy:
         src: "{{ gitdir.path }}/{{ item.src }}"
         remote_src: yes
-        dest: "{{ tempdir.path }}/paperless-ng/{{ item.dest | default('') }}"
+        dest: "{{ tempdir.path }}/paperless-ngx/{{ item.dest | default('') }}"
       with_items:
         - src: CONTRIBUTING.md
         - src: LICENSE
@@ -70,13 +70,13 @@
       copy:
         src: "{{ item.path }}"
         remote_src: yes
-        dest: "{{ tempdir.path }}/paperless-ng/scripts/"
+        dest: "{{ tempdir.path }}/paperless-ngx/scripts/"
       with_items:
         - "{{ glob.files }}"
 
     - name: copy sources
       command:
-        cmd: "cp -r src/ {{ tempdir.path }}/paperless-ng/src"
+        cmd: "cp -r src/ {{ tempdir.path }}/paperless-ngx/src"
       args:
         chdir: "{{ gitdir.path }}"
 
@@ -91,12 +91,12 @@
     - name: compile messages
       command: "{{ gitdir.path }}/.venv/bin/python3 manage.py compilemessages"
       args:
-        chdir: "{{ tempdir.path }}/paperless-ng/src/"
+        chdir: "{{ tempdir.path }}/paperless-ngx/src/"
 
     - name: collect static files
       command: "{{ gitdir.path }}/.venv/bin/python3 manage.py collectstatic --no-input"
       args:
-        chdir: "{{ tempdir.path }}/paperless-ng/src/"
+        chdir: "{{ tempdir.path }}/paperless-ngx/src/"
 
     - name: remove pycache directories
       shell: find . -name __pycache__ | xargs rm -r

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -1,13 +1,13 @@
 ---
 - name: install dev dependencies
-  apt:
+  ansible.builtin.apt:
     pkg:
       - git
       - npm
       - gettext
 
 - name: create output directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ paperlessng_system_user }}"
@@ -19,20 +19,20 @@
 
 - block:
     - name: create temporary git directory
-      tempfile:
+      ansible.builtin.tempfile:
         state: directory
         path: "{{ paperlessng_directory }}"
       register: gitdir
 
     - name: pull paperless-ngx
-      git:
+      ansible.builtin.git:
         repo: https://github.com/paperless-ngx/paperless-ngx.git
         dest: "{{ gitdir.path }}"
         version: "{{ paperlessng_version }}"
-        refspec: "+refs/pull/*:refs/pull/*"
+        refspec: +refs/pull/*:refs/pull/*
 
     - name: compile frontend
-      command:
+      ansible.builtin.command:
         cmd: "{{ item }}"
       args:
         chdir: "{{ gitdir.path }}/src-ui"
@@ -43,9 +43,9 @@
         - ./node_modules/.bin/ng build --prod
 
     - name: copy application into place
-      copy:
+      ansible.builtin.copy:
         src: "{{ gitdir.path }}/{{ item.src }}"
-        remote_src: yes
+        remote_src: true
         dest: "{{ tempdir.path }}/paperless-ngx/{{ item.dest | default('') }}"
       with_items:
         - src: CONTRIBUTING.md
@@ -56,10 +56,10 @@
         - src: requirements.txt
         - src: gunicorn.conf.py
         - src: paperless.conf.example
-          dest: "paperless.conf"
+          dest: paperless.conf
 
     - name: glob all scripts
-      find:
+      ansible.builtin.find:
         paths: ["{{ gitdir.path }}/scripts/"]
         patterns:
           - "*.service"
@@ -67,46 +67,46 @@
       register: glob
 
     - name: copy scripts
-      copy:
+      ansible.builtin.copy:
         src: "{{ item.path }}"
-        remote_src: yes
+        remote_src: true
         dest: "{{ tempdir.path }}/paperless-ngx/scripts/"
       with_items:
         - "{{ glob.files }}"
 
     - name: copy sources
-      command:
-        cmd: "cp -r src/ {{ tempdir.path }}/paperless-ngx/src"
+      ansible.builtin.command:
+        cmd: cp -r src/ {{ tempdir.path }}/paperless-ngx/src
       args:
         chdir: "{{ gitdir.path }}"
 
     - name: create paperlessng venv
-      command:
-        cmd: "python3 -m virtualenv {{ gitdir.path }}/.venv/ -p /usr/bin/python3"
+      ansible.builtin.command:
+        cmd: python3 -m virtualenv {{ gitdir.path }}/.venv/ -p /usr/bin/python3
 
     - name: install paperlessng requirements
-      command:
+      ansible.builtin.command:
         cmd: "{{ gitdir.path }}/.venv/bin/python3 -m pip install -r {{ gitdir.path }}/requirements.txt"
 
     - name: compile messages
-      command: "{{ gitdir.path }}/.venv/bin/python3 manage.py compilemessages"
+      ansible.builtin.command: "{{ gitdir.path }}/.venv/bin/python3 manage.py compilemessages"
       args:
         chdir: "{{ tempdir.path }}/paperless-ngx/src/"
 
     - name: collect static files
-      command: "{{ gitdir.path }}/.venv/bin/python3 manage.py collectstatic --no-input"
+      ansible.builtin.command: "{{ gitdir.path }}/.venv/bin/python3 manage.py collectstatic --no-input"
       args:
         chdir: "{{ tempdir.path }}/paperless-ngx/src/"
 
     - name: remove pycache directories
-      shell: find . -name __pycache__ | xargs rm -r
+      ansible.builtin.shell: find . -name __pycache__ | xargs rm -r
       args:
         chdir: "{{ tempdir.path }}"
 
     - name: remove temporary git directory
-      file:
+      ansible.builtin.file:
         path: "{{ gitdir.path }}"
         state: absent
 
-  become: yes
+  become: true
   become_user: "{{ paperlessng_system_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: verify operating system
-  fail:
+  ansible.builtin.fail:
     msg: Sorry, only Debian and Ubuntu supported at the moment.
   when: not(ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
 
 - name: Update all packages to the latest version
-  apt:
-    upgrade: yes
+  ansible.builtin.apt:
+    upgrade: true
     state: latest
 
 - name: install base dependencies
-  apt:
-    update_cache: yes
+  ansible.builtin.apt:
+    update_cache: true
     pkg:
       # paperless-ngx
       - python3-pip
@@ -46,28 +46,28 @@
 # upstream virtualenv in Ubuntu 20.04 is broken
 # https://github.com/pypa/virtualenv/issues/1873
 - name: install python virtualenv
-  pip:
+  ansible.builtin.pip:
     name: virtualenv
     extra_args: --upgrade
 
 - name: install ocr languages
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ paperlessng_ocr_languages | map('regex_replace', '^(.*)$', 'tesseract-ocr-\\1') | map('replace', '_', '-') | list }}"
 
 - name: set up notesalexp repository key (for jbig2enc)
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://notesalexp.org/debian/alexp_key.asc
     state: present
   when: paperlessng_use_jbig2enc
 
 - name: set up notesalexp repository (for jbig2enc)
-  apt_repository:
-    repo: "deb https://notesalexp.org/debian/{{ ansible_distribution_release }}/ {{ ansible_distribution_release }} main"
+  ansible.builtin.apt_repository:
+    repo: deb https://notesalexp.org/debian/{{ ansible_distribution_release }}/ {{ ansible_distribution_release }} main
     state: present
   when: paperlessng_use_jbig2enc
 
 - name: set up notesalexp repository pinning
-  copy:
+  ansible.builtin.copy:
     content: |
       Package: *
       Pin: release o=notesalexp.org
@@ -80,40 +80,40 @@
   when: paperlessng_use_jbig2enc
 
 - name: install jbig2enc
-  apt:
+  ansible.builtin.apt:
     pkg: jbig2enc
-    update_cache: yes
+    update_cache: true
   when: paperlessng_use_jbig2enc
 
 - name: install redis
-  apt:
+  ansible.builtin.apt:
     pkg: redis-server
   when: paperlessng_redis_host == 'localhost' or paperlessng_redis_host == '127.0.0.1'
 
 - name: enable redis
-  systemd:
+  ansible.builtin.systemd:
     name: redis-server
-    enabled: yes
-    masked: no
+    enabled: true
+    masked: false
     state: started
   when: paperlessng_redis_host == 'localhost' or paperlessng_redis_host == '127.0.0.1'
 
 - name: create paperless system group
-  group:
+  ansible.builtin.group:
     name: "{{ paperlessng_system_group }}"
 
 - name: create paperless system user
-  user:
+  ansible.builtin.user:
     name: "{{ paperlessng_system_user }}"
     groups:
       - "{{ paperlessng_system_group }}"
     shell: /usr/sbin/nologin
     # GNUPG_HOME required due to paperless db.py
-    create_home: yes
+    create_home: true
 
 - block:
     - name: get latest release version
-      uri:
+      ansible.builtin.uri:
         url: https://api.github.com/repos/paperless-ngx/paperless-ngx/releases/latest
         method: GET
       register: latest_release
@@ -124,18 +124,18 @@
 
 - block:
     - name: check if version can be found on github
-      uri:
-        url: "https://api.github.com/repos/paperless-ngx/paperless-ngx/commits/{{ paperlessng_version }}"
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/paperless-ngx/paperless-ngx/commits/{{ paperlessng_version }}
         method: GET
         status_code: [200, 404, 422]
       register: commit
     - name: get commit version for your configuration
-      set_fact:
+      ansible.builtin.set_fact:
         paperlessng_commit: "{{ commit.json | json_query('sha') }}"
       when: commit.status == 200
     - name: get commit for target commit-or-ref check
-      fail:
-        msg: "Can not determine commit from `paperlessng_version=={{ paperlessng_version }}`!"
+      ansible.builtin.fail:
+        msg: Can not determine commit from `paperlessng_version=={{ paperlessng_version }}`!
       when: commit.status != 200
 
 - name: check for existing paperless-ngx version file
@@ -144,34 +144,34 @@
   register: paperlessng_current_commitfile
 
 - name: get the current installed version as commit
-  command:
-    cmd: "cat {{ paperlessng_directory }}/.installed_version"
-  changed_when: 'paperlessng_current_commit.stdout != paperlessng_commit | string'
+  ansible.builtin.command:
+    cmd: cat {{ paperlessng_directory }}/.installed_version
+  changed_when: paperlessng_current_commit.stdout != paperlessng_commit | string
   failed_when: false
-  ignore_errors: yes
+  ignore_errors: true
   register: paperlessng_current_commit
   when: paperlessng_current_commitfile.stat.exists
 
 - name: register current state
-  set_fact:
-    fresh_installation: '{{ not paperlessng_current_commitfile.stat.exists }}'
+  ansible.builtin.set_fact:
+    fresh_installation: "{{ not paperlessng_current_commitfile.stat.exists }}"
     update_installation: false
     reconfigure_only: false
 
 - name: register current existing state
-  set_fact:
-    update_installation: '{{ paperlessng_current_commit.stdout != paperlessng_commit | string }}'
+  ansible.builtin.set_fact:
+    update_installation: "{{ paperlessng_current_commit.stdout != paperlessng_commit | string }}"
     reconfigure_only: "{{ paperlessng_current_commit.stdout == paperlessng_commit | string }}"
   when: not fresh_installation
 
 - block:
     - name: backup current paperless-ngx installation
-      copy:
+      ansible.builtin.copy:
         src: "{{ paperlessng_directory }}"
-        remote_src: yes
+        remote_src: true
         dest: "{{ paperlessng_directory }}-{{ ansible_date_time.iso8601 }}/"
     - name: remove current paperless sources
-      file:
+      ansible.builtin.file:
         path: "{{ paperlessng_directory }}/{{ item }}"
         state: absent
       with_items:
@@ -184,7 +184,7 @@
 
 - block:
     - name: create paperless-ngx directory and set permissions
-      file:
+      ansible.builtin.file:
         path: "{{ paperlessng_directory }}"
         state: directory
         owner: "{{ paperlessng_system_user }}"
@@ -192,8 +192,8 @@
         mode: "750"
 
     - name: create temporary directory
-      become: yes
-      tempfile:
+      become: true
+      ansible.builtin.tempfile:
         state: directory
         path: "{{ paperlessng_directory }}"
       register: tempdir
@@ -207,20 +207,20 @@
       when: paperlessng_install_method == "precompiledrelease"
 
     - name: change owner and permissions of paperless-ngx
-      command:
+      ansible.builtin.command:
         cmd: "{{ item }}"
         warn: false
       with_items:
-        - "chown -R {{ paperlessng_system_user }}:{{ paperlessng_system_group }} {{ tempdir.path }}"
-        - "find {{ tempdir.path }} -type d -exec chmod 0750 {} ;"
-        - "find {{ tempdir.path }} -type f -exec chmod 0640 {} ;"
+        - chown -R {{ paperlessng_system_user }}:{{ paperlessng_system_group }} {{ tempdir.path }}
+        - find {{ tempdir.path }} -type d -exec chmod 0750 {} ;
+        - find {{ tempdir.path }} -type f -exec chmod 0640 {} ;
 
     - name: move paperless-ngx
-      command:
-        cmd: "cp -a {{ tempdir.path }}/paperless-ngx/. {{ paperlessng_directory }}"
+      ansible.builtin.command:
+        cmd: cp -a {{ tempdir.path }}/paperless-ngx/. {{ paperlessng_directory }}
 
     - name: store commit hash of installed version
-      copy:
+      ansible.builtin.copy:
         content: "{{ paperlessng_commit }}"
         dest: "{{ paperlessng_directory }}/.installed_version"
         owner: "{{ paperlessng_system_user }}"
@@ -228,13 +228,13 @@
         mode: "0440"
 
     - name: remove temporary directory
-      file:
+      ansible.builtin.file:
         path: "{{ tempdir.path }}"
         state: absent
   when: not reconfigure_only
 
 - name: create paperless-ngx directories and set permissions
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ paperlessng_system_user }}"
@@ -250,147 +250,147 @@
     - "{{ paperlessng_consumption_dir }}"
 
 - name: rename initial config
-  command:
-    cmd: "mv -f {{ paperlessng_directory }}/paperless.conf {{ paperlessng_directory }}/paperless.conf.template"
+  ansible.builtin.command:
+    cmd: mv -f {{ paperlessng_directory }}/paperless.conf {{ paperlessng_directory }}/paperless.conf.template
     removes: "{{ paperlessng_directory }}/paperless.conf"
 
 - name: configure paperless-ngx
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ paperlessng_directory }}/paperless.conf.template"
-    regexp: "^#?{{ item.regexp }}="
+    regexp: ^#?{{ item.regexp }}=
     line: "{{ item.line }}"
   with_items:
     # Required services
     - regexp: PAPERLESS_REDIS
-      line: "PAPERLESS_REDIS=redis://{{ paperlessng_redis_host }}:{{ paperlessng_redis_port }}"
+      line: PAPERLESS_REDIS=redis://{{ paperlessng_redis_host }}:{{ paperlessng_redis_port }}
     # Paths and folders
     - regexp: PAPERLESS_CONSUMPTION_DIR
-      line: "PAPERLESS_CONSUMPTION_DIR={{ paperlessng_consumption_dir }}"
+      line: PAPERLESS_CONSUMPTION_DIR={{ paperlessng_consumption_dir }}
     - regexp: PAPERLESS_EXPORT_DIR
-      line: "PAPERLESS_EXPORT_DIR={{ paperlessng_export_dir }}"
+      line: PAPERLESS_EXPORT_DIR={{ paperlessng_export_dir }}
     - regexp: PAPERLESS_DATA_DIR
-      line: "PAPERLESS_DATA_DIR={{ paperlessng_data_dir }}"
+      line: PAPERLESS_DATA_DIR={{ paperlessng_data_dir }}
     - regexp: PAPERLESS_TRASH_DIR
-      line: "PAPERLESS_TRASH_DIR={{ paperlessng_trash_dir }}"
+      line: PAPERLESS_TRASH_DIR={{ paperlessng_trash_dir }}
     - regexp: PAPERLESS_MEDIA_ROOT
-      line: "PAPERLESS_MEDIA_ROOT={{ paperlessng_media_root }}"
+      line: PAPERLESS_MEDIA_ROOT={{ paperlessng_media_root }}
     - regexp: PAPERLESS_STATICDIR
-      line: "PAPERLESS_STATICDIR={{ paperlessng_staticdir }}"
+      line: PAPERLESS_STATICDIR={{ paperlessng_staticdir }}
     - regexp: PAPERLESS_FILENAME_FORMAT
-      line: "PAPERLESS_FILENAME_FORMAT={{ paperlessng_filename_format }}"
+      line: PAPERLESS_FILENAME_FORMAT={{ paperlessng_filename_format }}
     - regexp: PAPERLESS_LOGGING_DIR
-      line: "PAPERLESS_LOGGING_DIR={{ paperlessng_logging_dir }}"
+      line: PAPERLESS_LOGGING_DIR={{ paperlessng_logging_dir }}
     # Hosting & Security
     - regexp: PAPERLESS_SECRET_KEY
-      line: "PAPERLESS_SECRET_KEY={{ paperlessng_secret_key }}"
+      line: PAPERLESS_SECRET_KEY={{ paperlessng_secret_key }}
     - regexp: PAPERLESS_ALLOWED_HOSTS
-      line: "PAPERLESS_ALLOWED_HOSTS={{ paperlessng_allowed_hosts }}"
+      line: PAPERLESS_ALLOWED_HOSTS={{ paperlessng_allowed_hosts }}
     - regexp: PAPERLESS_CORS_ALLOWED_HOSTS
-      line: "PAPERLESS_CORS_ALLOWED_HOSTS={{ paperlessng_cors_allowed_hosts }}"
+      line: PAPERLESS_CORS_ALLOWED_HOSTS={{ paperlessng_cors_allowed_hosts }}
     - regexp: PAPERLESS_FORCE_SCRIPT_NAME
-      line: "PAPERLESS_FORCE_SCRIPT_NAME={{ paperlessng_force_script_name }}"
+      line: PAPERLESS_FORCE_SCRIPT_NAME={{ paperlessng_force_script_name }}
     - regexp: PAPERLESS_STATIC_URL
-      line: "PAPERLESS_STATIC_URL={{ paperlessng_static_url }}"
+      line: PAPERLESS_STATIC_URL={{ paperlessng_static_url }}
     - regexp: PAPERLESS_AUTO_LOGIN_USERNAME
-      line: "PAPERLESS_AUTO_LOGIN_USERNAME={{ paperlessng_auto_login_username }}"
+      line: PAPERLESS_AUTO_LOGIN_USERNAME={{ paperlessng_auto_login_username }}
     - regexp: PAPERLESS_COOKIE_PREFIX
-      line: "PAPERLESS_COOKIE_PREFIX={{ paperlessng_cookie_prefix }}"
+      line: PAPERLESS_COOKIE_PREFIX={{ paperlessng_cookie_prefix }}
     - regexp: PAPERLESS_ENABLE_HTTP_REMOTE_USER
-      line: "PAPERLESS_ENABLE_HTTP_REMOTE_USER={{ paperlessng_enable_http_remote_user }}"
+      line: PAPERLESS_ENABLE_HTTP_REMOTE_USER={{ paperlessng_enable_http_remote_user }}
     - regexp: PAPERLESS_URL
-      line: "PAPERLESS_URL={{ paperlessng_url }}"
+      line: PAPERLESS_URL={{ paperlessng_url }}
     # OCR settings
     - regexp: PAPERLESS_OCR_LANGUAGE
-      line: "PAPERLESS_OCR_LANGUAGE={{ paperlessng_ocr_languages | join('+') | replace('-','_') }}"
+      line: PAPERLESS_OCR_LANGUAGE={{ paperlessng_ocr_languages | join('+') | replace('-','_') }}
     - regexp: PAPERLESS_OCR_MODE
-      line: "PAPERLESS_OCR_MODE={{ paperlessng_ocr_mode }}"
+      line: PAPERLESS_OCR_MODE={{ paperlessng_ocr_mode }}
     - regexp: PAPERLESS_OCR_CLEAN
-      line: "PAPERLESS_OCR_CLEAN={{ paperlessng_ocr_clean }}"
+      line: PAPERLESS_OCR_CLEAN={{ paperlessng_ocr_clean }}
     - regexp: PAPERLESS_OCR_DESKEW
-      line: "PAPERLESS_OCR_DESKEW={{ paperlessng_ocr_deskew }}"
+      line: PAPERLESS_OCR_DESKEW={{ paperlessng_ocr_deskew }}
     - regexp: PAPERLESS_OCR_ROTATE_PAGES
-      line: "PAPERLESS_OCR_ROTATE_PAGES={{ paperlessng_ocr_rotate_pages }}"
+      line: PAPERLESS_OCR_ROTATE_PAGES={{ paperlessng_ocr_rotate_pages }}
     - regexp: PAPERLESS_OCR_ROTATE_PAGES_THRESHOLD
-      line: "PAPERLESS_OCR_ROTATE_PAGES_THRESHOLD={{ paperlessng_ocr_rotate_pages_threshold }}"
+      line: PAPERLESS_OCR_ROTATE_PAGES_THRESHOLD={{ paperlessng_ocr_rotate_pages_threshold }}
     - regexp: PAPERLESS_OCR_OUTPUT_TYPE
-      line: "PAPERLESS_OCR_OUTPUT_TYPE={{ paperlessng_ocr_output_type }}"
+      line: PAPERLESS_OCR_OUTPUT_TYPE={{ paperlessng_ocr_output_type }}
     - regexp: PAPERLESS_OCR_PAGES
-      line: "PAPERLESS_OCR_PAGES={{ paperlessng_ocr_pages }}"
+      line: PAPERLESS_OCR_PAGES={{ paperlessng_ocr_pages }}
     - regexp: PAPERLESS_OCR_IMAGE_DPI
-      line: "PAPERLESS_OCR_IMAGE_DPI={{ paperlessng_ocr_image_dpi }}"
+      line: PAPERLESS_OCR_IMAGE_DPI={{ paperlessng_ocr_image_dpi }}
     - regexp: PAPERLESS_OCR_USER_ARGS
       line: "PAPERLESS_OCR_USER_ARGS={{ paperlessng_ocr_user_args | combine({'jbig2_lossy': true} if paperlessng_big2enc_lossy else {}) | to_json }}"
     # Tika settings
     - regexp: PAPERLESS_TIKA_ENABLED
-      line: "PAPERLESS_TIKA_ENABLED={{ paperlessng_tika_enabled }}"
+      line: PAPERLESS_TIKA_ENABLED={{ paperlessng_tika_enabled }}
     - regexp: PAPERLESS_TIKA_ENDPOINT
-      line: "PAPERLESS_TIKA_ENDPOINT={{ paperlessng_tika_endpoint }}"
+      line: PAPERLESS_TIKA_ENDPOINT={{ paperlessng_tika_endpoint }}
     - regexp: PAPERLESS_TIKA_GOTENBERG_ENDPOINT
-      line: "PAPERLESS_TIKA_GOTENBERG_ENDPOINT={{ paperlessng_tika_gotenberg_endpoint }}"
+      line: PAPERLESS_TIKA_GOTENBERG_ENDPOINT={{ paperlessng_tika_gotenberg_endpoint }}
     # Software tweaks
     - regexp: PAPERLESS_TIME_ZONE
-      line: "PAPERLESS_TIME_ZONE={{ paperlessng_time_zone }}"
+      line: PAPERLESS_TIME_ZONE={{ paperlessng_time_zone }}
     - regexp: PAPERLESS_CONSUMER_POLLING
-      line: "PAPERLESS_CONSUMER_POLLING={{ paperlessng_consumer_polling }}"
+      line: PAPERLESS_CONSUMER_POLLING={{ paperlessng_consumer_polling }}
     - regexp: PAPERLESS_CONSUMER_DELETE_DUPLICATES
-      line: "PAPERLESS_CONSUMER_DELETE_DUPLICATES={{ paperlessng_consumer_delete_duplicates }}"
+      line: PAPERLESS_CONSUMER_DELETE_DUPLICATES={{ paperlessng_consumer_delete_duplicates }}
     - regexp: PAPERLESS_CONSUMER_RECURSIVE
-      line: "PAPERLESS_CONSUMER_RECURSIVE={{ paperlessng_consumer_recursive }}"
+      line: PAPERLESS_CONSUMER_RECURSIVE={{ paperlessng_consumer_recursive }}
     - regexp: PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS
-      line: "PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS={{ paperlessng_consumer_subdirs_as_tags }}"
+      line: PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS={{ paperlessng_consumer_subdirs_as_tags }}
     - regexp: PAPERLESS_CONVERT_MEMORY_LIMIT
-      line: "PAPERLESS_CONVERT_MEMORY_LIMIT={{ paperlessng_convert_memory_limit }}"
+      line: PAPERLESS_CONVERT_MEMORY_LIMIT={{ paperlessng_convert_memory_limit }}
     - regexp: PAPERLESS_CONVERT_TMPDIR
-      line: "PAPERLESS_CONVERT_TMPDIR={{ paperlessng_convert_tmpdir }}"
+      line: PAPERLESS_CONVERT_TMPDIR={{ paperlessng_convert_tmpdir }}
     - regexp: PAPERLESS_OPTIMIZE_THUMBNAILS
-      line: "PAPERLESS_OPTIMIZE_THUMBNAILS={{ paperlessng_optimize_thumbnails }}"
+      line: PAPERLESS_OPTIMIZE_THUMBNAILS={{ paperlessng_optimize_thumbnails }}
     - regexp: PAPERLESS_PRE_CONSUME_SCRIPT
-      line: "PAPERLESS_PRE_CONSUME_SCRIPT={{ paperlessng_pre_consume_script }}"
+      line: PAPERLESS_PRE_CONSUME_SCRIPT={{ paperlessng_pre_consume_script }}
     - regexp: PAPERLESS_POST_CONSUME_SCRIPT
-      line: "PAPERLESS_POST_CONSUME_SCRIPT={{ paperlessng_post_consume_script }}"
+      line: PAPERLESS_POST_CONSUME_SCRIPT={{ paperlessng_post_consume_script }}
     - regexp: PAPERLESS_FILENAME_DATE_ORDER
-      line: "PAPERLESS_FILENAME_DATE_ORDER={{ paperlessng_filename_date_order }}"
+      line: PAPERLESS_FILENAME_DATE_ORDER={{ paperlessng_filename_date_order }}
     - regexp: PAPERLESS_THUMBNAIL_FONT_NAME
-      line: "PAPERLESS_THUMBNAIL_FONT_NAME={{ paperlessng_thumbnail_font_name }}"
+      line: PAPERLESS_THUMBNAIL_FONT_NAME={{ paperlessng_thumbnail_font_name }}
     - regexp: PAPERLESS_IGNORE_DATES
-      line: "PAPERLESS_IGNORE_DATES={{ paperlessng_ignore_dates }}"
+      line: PAPERLESS_IGNORE_DATES={{ paperlessng_ignore_dates }}
     - regexp: PAPERLESS_ENABLE_UPDATE_CHECK
-      line: "PAPERLESS_ENABLE_UPDATE_CHECK={{ paperlessng_enable_update_check }}"
-  no_log: yes
+      line: PAPERLESS_ENABLE_UPDATE_CHECK={{ paperlessng_enable_update_check }}
+  no_log: true
 
 - name: configure paperless-ngx database [sqlite]
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ paperlessng_directory }}/paperless.conf.template"
-    regexp: "^#?PAPERLESS_DBHOST=(.*)$"
-    line: '#PAPERLESS_DBHOST=\1'
-    backrefs: yes
+    regexp: ^#?PAPERLESS_DBHOST=(.*)$
+    line: "#PAPERLESS_DBHOST=\\1"
+    backrefs: true
   when: paperlessng_db_type == 'sqlite'
 
 - name: configure paperless-ngx database [postgresql]
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ paperlessng_directory }}/paperless.conf.template"
-    regexp: "^#?{{ item.regexp }}="
+    regexp: ^#?{{ item.regexp }}=
     line: "{{ item.line }}"
   with_items:
     - regexp: PAPERLESS_DBHOST
-      line: "PAPERLESS_DBHOST={{ paperlessng_db_host }}"
+      line: PAPERLESS_DBHOST={{ paperlessng_db_host }}
     - regexp: PAPERLESS_DBPORT
-      line: "PAPERLESS_DBPORT={{ paperlessng_db_port }}"
+      line: PAPERLESS_DBPORT={{ paperlessng_db_port }}
     - regexp: PAPERLESS_DBNAME
-      line: "PAPERLESS_DBNAME={{ paperlessng_db_name }}"
+      line: PAPERLESS_DBNAME={{ paperlessng_db_name }}
     - regexp: PAPERLESS_DBUSER
-      line: "PAPERLESS_DBUSER={{ paperlessng_db_user }}"
+      line: PAPERLESS_DBUSER={{ paperlessng_db_user }}
     - regexp: PAPERLESS_DBPASS
-      line: "PAPERLESS_DBPASS={{ paperlessng_db_pass }}"
+      line: PAPERLESS_DBPASS={{ paperlessng_db_pass }}
     - regexp: PAPERLESS_DBSSLMODE
-      line: "PAPERLESS_DBSSLMODE={{ paperlessng_db_sslmode }}"
+      line: PAPERLESS_DBSSLMODE={{ paperlessng_db_sslmode }}
   when: paperlessng_db_type == 'postgresql'
-  no_log: yes
+  no_log: true
 
 - name: deploy paperless-ngx configuration
-  copy:
+  ansible.builtin.copy:
     src: "{{ paperlessng_directory }}/paperless.conf.template"
-    remote_src: yes
+    remote_src: true
     dest: /etc/paperless.conf
     owner: root
     group: root
@@ -398,15 +398,15 @@
   register: configuration
 
 - name: create paperlessng venv
-  become: yes
-  command:
-    cmd: "python3 -m venv {{ paperlessng_virtualenv }}"
+  become: true
+  ansible.builtin.command:
+    cmd: python3 -m venv {{ paperlessng_virtualenv }}
     creates: "{{ paperlessng_virtualenv }}"
   register: venv
 
 - name: install latest pip
-  become: yes
-  pip:
+  become: true
+  ansible.builtin.pip:
     name: pip
     executable: "{{ paperlessng_virtualenv }}/bin/pip3"
     state: latest
@@ -414,120 +414,113 @@
 
 - block:
     - name: install paperlessng requirements
-      become: yes
-      pip:
+      become: true
+      ansible.builtin.pip:
         requirements: "{{ paperlessng_directory }}/requirements.txt"
         executable: "{{ paperlessng_virtualenv }}/bin/pip3"
         extra_args: --upgrade
     - name: migrate database schema
-      become: yes
+      become: true
       command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py migrate"
       register: database_schema
       changed_when: '"No migrations to apply." not in database_schema.stdout'
   when: not reconfigure_only
 
 - name: configure paperless superuser
-  become: yes
-  command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py manage_superuser"
+  become: true
+  ansible.builtin.command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py manage_superuser"
   environment:
-      PAPERLESS_ADMIN_USER: "{{ paperlessng_superuser_name }}"
-      PAPERLESS_ADMIN_MAIL: "{{ paperlessng_superuser_email }}"
-      PAPERLESS_ADMIN_PASSWORD: "{{ paperlessng_superuser_password }}"
+    PAPERLESS_ADMIN_USER: "{{ paperlessng_superuser_name }}"
+    PAPERLESS_ADMIN_MAIL: "{{ paperlessng_superuser_email }}"
+    PAPERLESS_ADMIN_PASSWORD: "{{ paperlessng_superuser_password }}"
   register: superuser
   changed_when: '"Created superuser" in superuser.stdout'
-  no_log: yes
+  no_log: true
 
 - name: set ownership and permissions on paperlessng venv
-  file:
+  ansible.builtin.file:
     path: "{{ paperlessng_virtualenv }}"
     state: directory
-    recurse: yes
+    recurse: true
     owner: "{{ paperlessng_system_user }}"
     group: "{{ paperlessng_system_group }}"
     mode: g-w,o-rwx
   when: venv.changed or not reconfigure_only
 
 - name: configure ghostscript for PDF
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/ImageMagick-6/policy.xml
-    regexp: '(\s+)<policy domain="coder" rights=".*" pattern="PDF" />'
-    line: '\1<policy domain="coder" rights="read|write" pattern="PDF" />'
-    backrefs: yes
+    regexp: (\s+)<policy domain="coder" rights=".*" pattern="PDF" />
+    line: \1<policy domain="coder" rights="read|write" pattern="PDF" />
+    backrefs: true
 
 - name: configure gunicorn web server
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ paperlessng_directory }}/gunicorn.conf.py"
-    regexp: '^bind = '
-    line: "bind = '{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}'"
+    regexp: "^bind = "
+    line: bind = '{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}'
 
 - name: configure systemd services
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/{{ item[0] }}"
-    section: "Service"
+    section: Service
     option: "{{ item[1].option  }}"
     value: "{{ item[1].value }}"
   with_nested:
-    - [
-        paperless-consumer.service,
-        paperless-scheduler.service,
-        paperless-webserver.service,
-      ]
-    - [
-        # https://www.freedesktop.org/software/systemd/man/systemd.exec.html
-        { option: "User", value: "{{ paperlessng_system_user }}" },
-        { option: "Group", value: "{{ paperlessng_system_group }}" },
-        { option: "WorkingDirectory", value: "{{ paperlessng_directory }}/src" },
-        { option: "ProtectSystem", value: "full" },
-        { option: "NoNewPrivileges", value: "true" },
-        { option: "PrivateUsers", value: "true" },
-        { option: "PrivateDevices", value: "true" },
-      ]
-
+    - [paperless-consumer.service, paperless-scheduler.service, paperless-webserver.service]
+    # https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+    -   - { option: User, value: "{{ paperlessng_system_user }}" }
+        - { option: Group, value: "{{ paperlessng_system_group }}" }
+        - { option: WorkingDirectory, value: "{{ paperlessng_directory }}/src" }
+        - { option: ProtectSystem, value: full }
+        - { option: NoNewPrivileges, value: "true" }
+        - { option: PrivateUsers, value: "true" }
+        - { option: PrivateDevices, value: "true" }
 - name: configure paperless-consumer service
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-consumer.service"
-    section: "Service"
-    option: "ExecStart"
+    section: Service
+    option: ExecStart
     value: "{{ paperlessng_virtualenv }}/bin/python3 manage.py document_consumer"
 
 - name: remove redis from paperless-consumer service if external
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-consumer.service"
-    section: "Unit"
-    option: "Requires"
-    value: "redis.service"
+    section: Unit
+    option: Requires
+    value: redis.service
     state: absent
   when: paperlessng_redis_host != 'localhost' or paperlessng_redis_host != '127.0.0.1'
 
 - name: configure paperless-scheduler service
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-scheduler.service"
-    section: "Service"
-    option: "ExecStart"
+    section: Service
+    option: ExecStart
     value: "{{ paperlessng_virtualenv }}/bin/python3 manage.py qcluster"
 
 - name: remove redis from paperless-scheduler service if external
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-scheduler.service"
-    section: "Unit"
-    option: "Requires"
-    value: "redis.service"
+    section: Unit
+    option: Requires
+    value: redis.service
     state: absent
   when: paperlessng_redis_host != 'localhost' or paperlessng_redis_host != '127.0.0.1'
 
 - name: configure paperless-webserver service
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-webserver.service"
-    section: "Service"
-    option: "ExecStart"
+    section: Service
+    option: ExecStart
     value: "{{ paperlessng_virtualenv }}/bin/gunicorn -c {{ paperlessng_directory }}/gunicorn.conf.py paperless.asgi:application"
 
 - name: remove redis from paperless-webserver service if external
-  ini_file:
+  community.general.ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-webserver.service"
-    section: "Unit"
-    option: "Requires"
-    value: "redis.service"
+    section: Unit
+    option: Requires
+    value: redis.service
     state: absent
   when: paperlessng_redis_host != 'localhost' or paperlessng_redis_host != '127.0.0.1'
 
@@ -578,10 +571,10 @@
     - paperlessng_is_lxc != "True"
 
 - name: copy systemd services
-  copy:
+  ansible.builtin.copy:
     src: "{{ paperlessng_directory }}/scripts/{{ item }}"
-    remote_src: yes
-    dest: "/etc/systemd/system/{{ item }}"
+    remote_src: true
+    dest: /etc/systemd/system/{{ item }}
   with_items:
     - paperless-consumer.service
     - paperless-scheduler.service
@@ -589,10 +582,10 @@
   register: paperless_services
 
 - name: reload systemd daemon
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
   with_items:
     - paperless-consumer
     - paperless-scheduler
@@ -600,10 +593,10 @@
   when: paperless_services.changed or configuration.changed
 
 - name: enable paperlessng services
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
-    enabled: yes
-    masked: no
+    enabled: true
+    masked: false
     state: started
   with_items:
     - paperless-consumer

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,17 +7,7 @@
 - name: Update all packages to the latest version
   apt:
     upgrade: yes
-
-- name: Check and set fact if consumption mount point exists
-  set_fact:
-    consumption_mount_exist: true
-  when: item.mount == '{{ paperlessng_consumption_dir }}'
-  loop: "{{ ansible_facts.mounts }}"
-
-- name: Show if consumption mount exists
-  debug:
-    msg: "Consumption mount point exists"
-  when: consumption_mount_exist == true
+    state: latest
 
 - name: install base dependencies
   apt:
@@ -164,8 +154,8 @@
 - name: register current state
   set_fact:
     fresh_installation: '{{ not paperlessng_current_commitfile.stat.exists }}'
-    update_installation: true
-    reconfigure_only: true
+    update_installation: false
+    reconfigure_only: false
 
 - name: register current existing state
   set_fact:
@@ -257,15 +247,7 @@
     - "{{ paperlessng_media_root }}"
     - "{{ paperlessng_staticdir }}"
     - "{{ paperlessng_export_dir }}"
-
-- name: create paperless-ngx consumption directory and set permissions
-  file:
-    path: "{{ paperlessng_consumption_dir }}"
-    state: directory
-    owner: "{{ paperlessng_system_user }}"
-    group: "{{ paperlessng_system_group }}"
-    mode: "750"
-  when: consumption_mount_exist == false
+    - "{{ paperlessng_consumption_dir }}"
 
 - name: rename initial config
   command:
@@ -580,7 +562,10 @@
       - nfs-utils
       - nfs4-acl-tools
     state: present
-  when: ansible_os_family == "RedHat" and paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True"
+  when: 
+    - ansible_os_family == "RedHat" 
+    - paperlessng_consumption_dir_nfs_enabled
+    - paperlessng_is_lxc != "True"
 
 - name: NFS utility present for debian-like
   ansible.builtin.apt:
@@ -588,7 +573,10 @@
       - nfs-common
       - nfs4-acl-tools
     state: present
-  when: ansible_os_family == "Debian" and paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True"
+  when: 
+    - ansible_os_family == "RedHat" 
+    - paperlessng_consumption_dir_nfs_enabled
+    - paperlessng_is_lxc != "True"
 
 - name: Check consumption mountpoint exists
   ansible.builtin.file:
@@ -597,7 +585,10 @@
     mode: "{{ paperlessng_consumption_dir_permission }}"
     owner: root
     group: root
-  when: paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True" and consumption_mount_exist == 'false'
+  when: 
+    - ansible_os_family == "RedHat" 
+    - paperlessng_consumption_dir_nfs_enabled
+    - paperlessng_is_lxc != "True"
 
 - name: Mount consumption share
   ansible.posix.mount:
@@ -606,8 +597,11 @@
     fstype: nfs
     opts: "{{ paperlessng_consumption_dir_myopts }}"
     state: mounted
-  when: paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True"
-
+  when: 
+    - ansible_os_family == "RedHat" 
+    - paperlessng_consumption_dir_nfs_enabled
+    - paperlessng_is_lxc != "True"
+    
 - name: copy systemd services
   copy:
     src: "{{ paperlessng_directory }}/scripts/{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
       - build-essential
       - python3-setuptools
       - python3-wheel
+      - python3-venv
       - git
 
 # upstream virtualenv in Ubuntu 20.04 is broken
@@ -192,7 +193,6 @@
 
     - name: create temporary directory
       become: yes
-      become_user: "{{ paperlessng_system_user }}"
       tempfile:
         state: directory
         path: "{{ paperlessng_directory }}"
@@ -226,7 +226,7 @@
         owner: "{{ paperlessng_system_user }}"
         group: "{{ paperlessng_system_group }}"
         mode: "0440"
-        
+
     - name: remove temporary directory
       file:
         path: "{{ tempdir.path }}"
@@ -399,15 +399,13 @@
 
 - name: create paperlessng venv
   become: yes
-  become_user: "{{ paperlessng_system_user }}"
   command:
-    cmd: "python3 -m virtualenv {{ paperlessng_virtualenv }} -p /usr/bin/python3"
+    cmd: "python3 -m venv {{ paperlessng_virtualenv }}"
     creates: "{{ paperlessng_virtualenv }}"
   register: venv
 
 - name: install latest pip
   become: yes
-  become_user: "{{ paperlessng_system_user }}"
   pip:
     name: pip
     executable: "{{ paperlessng_virtualenv }}/bin/pip3"
@@ -417,14 +415,12 @@
 - block:
     - name: install paperlessng requirements
       become: yes
-      become_user: "{{ paperlessng_system_user }}"
       pip:
         requirements: "{{ paperlessng_directory }}/requirements.txt"
         executable: "{{ paperlessng_virtualenv }}/bin/pip3"
         extra_args: --upgrade
     - name: migrate database schema
       become: yes
-      become_user: "{{ paperlessng_system_user }}"
       command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py migrate"
       register: database_schema
       changed_when: '"No migrations to apply." not in database_schema.stdout'
@@ -432,34 +428,13 @@
 
 - name: configure paperless superuser
   become: yes
-  become_user: "{{ paperlessng_system_user }}"
-  # "manage.py createsuperuser" only works on interactive TTYs
-  vars:
-    creation_script: |
-      from django.contrib.auth.models import User
-      from django.contrib.auth.hashers import get_hasher
-
-      if User.objects.filter(username='{{ paperlessng_superuser_name }}').exists():
-          user = User.objects.get(username='{{ paperlessng_superuser_name }}')
-          old = user.__dict__.copy()
-
-          user.is_superuser = True
-          user.email = '{{ paperlessng_superuser_email }}'
-          user.set_password('{{ paperlessng_superuser_password }}')
-          user.save()
-          new = user.__dict__
-
-          algorithm, iterations, old_salt, old_hash = old['password'].split('$')
-          new_password_old_salt = get_hasher(algorithm).encode(password='{{ paperlessng_superuser_password }}', salt=old_salt, iterations=int(iterations))
-          _, _, _, new_hash = new_password_old_salt.split('$')
-          if not (old_hash == new_hash and old['is_superuser'] == new['is_superuser'] and old['email'] == new['email']):
-              print('changed')
-      else:
-          User.objects.create_superuser('{{ paperlessng_superuser_name }}', '{{ paperlessng_superuser_email }}', '{{ paperlessng_superuser_password }}')
-          print('changed')
-  command: '{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py shell -c "{{ creation_script }}"'
+  command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py manage_superuser"
+  environment:
+      PAPERLESS_ADMIN_USER: "{{ paperlessng_superuser_name }}"
+      PAPERLESS_ADMIN_MAIL: "{{ paperlessng_superuser_email }}"
+      PAPERLESS_ADMIN_PASSWORD: "{{ paperlessng_superuser_password }}"
   register: superuser
-  changed_when: superuser.stdout == 'changed'
+  changed_when: '"Created superuser" in superuser.stdout'
   no_log: yes
 
 - name: set ownership and permissions on paperlessng venv
@@ -562,8 +537,8 @@
       - nfs-utils
       - nfs4-acl-tools
     state: present
-  when: 
-    - ansible_os_family == "RedHat" 
+  when:
+    - ansible_os_family == "RedHat"
     - paperlessng_consumption_dir_nfs_enabled
     - paperlessng_is_lxc != "True"
 
@@ -573,8 +548,8 @@
       - nfs-common
       - nfs4-acl-tools
     state: present
-  when: 
-    - ansible_os_family == "RedHat" 
+  when:
+    - ansible_os_family == "RedHat"
     - paperlessng_consumption_dir_nfs_enabled
     - paperlessng_is_lxc != "True"
 
@@ -585,8 +560,8 @@
     mode: "{{ paperlessng_consumption_dir_permission }}"
     owner: root
     group: root
-  when: 
-    - ansible_os_family == "RedHat" 
+  when:
+    - ansible_os_family == "RedHat"
     - paperlessng_consumption_dir_nfs_enabled
     - paperlessng_is_lxc != "True"
 
@@ -597,11 +572,11 @@
     fstype: nfs
     opts: "{{ paperlessng_consumption_dir_myopts }}"
     state: mounted
-  when: 
-    - ansible_os_family == "RedHat" 
+  when:
+    - ansible_os_family == "RedHat"
     - paperlessng_consumption_dir_nfs_enabled
     - paperlessng_is_lxc != "True"
-    
+
 - name: copy systemd services
   copy:
     src: "{{ paperlessng_directory }}/scripts/{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,26 @@
     msg: Sorry, only Debian and Ubuntu supported at the moment.
   when: not(ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
 
+- name: Update all packages to the latest version
+  apt:
+    upgrade: yes
+
+- name: Check and set fact if consumption mount point exists
+  set_fact:
+    consumption_mount_exist: true
+  when: item.mount == '{{ paperlessng_consumption_dir }}'
+  loop: "{{ ansible_facts.mounts }}"
+
+- name: Show if consumption mount exists
+  debug:
+    msg: "Consumption mount point exists"
+  when: consumption_mount_exist == true
+
 - name: install base dependencies
   apt:
     update_cache: yes
     pkg:
-      # paperless-ng
+      # paperless-ngx
       - python3-pip
       - python3-dev
       - fonts-liberation
@@ -18,6 +33,8 @@
       - libpq-dev
       - libmagic-dev
       - mime-support
+      - libzbar0
+      - poppler-utils
       # OCRmyPDF
       - unpaper
       - ghostscript
@@ -105,7 +122,7 @@
 - block:
     - name: get latest release version
       uri:
-        url: https://api.github.com/repos/jonaswinkler/paperless-ng/releases/latest
+        url: https://api.github.com/repos/paperless-ngx/paperless-ngx/releases/latest
         method: GET
       register: latest_release
     - name: parse latest release version
@@ -113,71 +130,50 @@
         paperlessng_version: "{{ latest_release.json['tag_name'] }}"
   when: paperlessng_version == "latest"
 
-- name: check if version is ref
-  fail:
-    msg: "Specifying `paperlessng_version` as git ref may not work as expected!"
-  ignore_errors: True  # Output failure (as warning), but don't consider play failed
-  when: paperlessng_version.startswith('refs/')
-
 - block:
-    - name: sanitize version string
-      set_fact:
-        paperlessng_version: "{{ paperlessng_version | regex_replace('^ng-(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
-    - name: get tag data
+    - name: check if version can be found on github
       uri:
-        url: https://api.github.com/repos/jonaswinkler/paperless-ng/tags
+        url: "https://api.github.com/repos/paperless-ngx/paperless-ngx/commits/{{ paperlessng_version }}"
         method: GET
-      register: tags
-    - name: get commit for target tag
+        status_code: [200, 404, 422]
+      register: commit
+    - name: get commit version for your configuration
       set_fact:
-        paperlessng_commit: "{{ tags.json | json_query('[?name==`ng-' + paperlessng_version +'`] | [0].commit.sha') }}"
-  when: paperlessng_version | regex_search("^(ng-)?(\d+\.\d+\.\d+)$")
+        paperlessng_commit: "{{ commit.json | json_query('sha') }}"
+      when: commit.status == 200
+    - name: get commit for target commit-or-ref check
+      fail:
+        msg: "Can not determine commit from `paperlessng_version=={{ paperlessng_version }}`!"
+      when: commit.status != 200
 
-- block:
-    - name: check if version is branch
-      uri:
-        url: "https://api.github.com/repos/jonaswinkler/paperless-ng/branches/{{ paperlessng_version }}"
-        method: GET
-        status_code: [200, 404]
-      register: branch
-    - name: get commit for target branch
-      set_fact:
-        paperlessng_commit: "{{ branch.json | json_query('commit.sha') }}"
-      when: branch.status == 200
-    - block:
-        - name: check if version is commit-or-ref
-          uri:
-            url: "https://api.github.com/repos/jonaswinkler/paperless-ng/commits/{{ paperlessng_version }}"
-            method: GET
-            status_code: [200, 404, 422]
-          register: commit
-        - name: get commit for target commit-or-ref
-          set_fact:
-            paperlessng_commit: "{{ commit.json | json_query('sha') }}"
-          when: commit.status == 200
-        - name: fail
-          fail:
-            msg: "Can not determine commit from `paperlessng_version=={{ paperlessng_version }}`!"
-          when: commit.status != 200
-      when: branch.status == 404
-  when: not(paperlessng_version | regex_search("^(ng-)?(\d+\.\d+\.\d+)$"))
+- name: check for existing paperless-ngx version file
+  ansible.builtin.stat:
+    path: "{{ paperlessng_directory }}/.installed_version"
+  register: paperlessng_current_commitfile
 
-- name: check for paperless-ng installation
+- name: get the current installed version as commit
   command:
     cmd: "cat {{ paperlessng_directory }}/.installed_version"
-  changed_when: '"No such file or directory" in paperlessng_current_commit.stderr or paperlessng_current_commit.stdout != paperlessng_commit | string'
+  changed_when: 'paperlessng_current_commit.stdout != paperlessng_commit | string'
   failed_when: false
   ignore_errors: yes
   register: paperlessng_current_commit
+  when: paperlessng_current_commitfile.stat.exists
 
 - name: register current state
   set_fact:
-    fresh_installation: '{{ "No such file or directory" in paperlessng_current_commit.stderr }}'
-    update_installation: '{{ "No such file or directory" not in paperlessng_current_commit.stderr and paperlessng_current_commit.stdout != paperlessng_commit | string }}'
+    fresh_installation: '{{ not paperlessng_current_commitfile.stat.exists }}'
+    update_installation: false
+    reconfigure_only: false
+
+- name: register current existing state
+  set_fact:
+    update_installation: '{{ paperlessng_current_commit.stdout != paperlessng_commit | string }}'
     reconfigure_only: "{{ paperlessng_current_commit.stdout == paperlessng_commit | string }}"
+  when: not fresh_installation
 
 - block:
-    - name: backup current paperless-ng installation
+    - name: backup current paperless-ngx installation
       copy:
         src: "{{ paperlessng_directory }}"
         remote_src: yes
@@ -195,13 +191,14 @@
   when: update_installation
 
 - block:
-    - name: create paperless-ng directory and set permissions
+    - name: create paperless-ngx directory and set permissions
       file:
         path: "{{ paperlessng_directory }}"
         state: directory
         owner: "{{ paperlessng_system_user }}"
         group: "{{ paperlessng_system_group }}"
         mode: "750"
+
     - name: create temporary directory
       become: yes
       become_user: "{{ paperlessng_system_user }}"
@@ -209,19 +206,16 @@
         state: directory
         path: "{{ paperlessng_directory }}"
       register: tempdir
-    - name: check if version is available as release archive
-      uri:
-        url: "https://github.com/jonaswinkler/paperless-ng/releases/download/ng-{{ paperlessng_version }}/paperless-ng-{{ paperlessng_version }}.tar.xz"
-        method: GET
-        status_code: [200, 404]
-      register: release_archive
-    - name: install paperless-ng from source
+
+    - name: install paperless-ngx from source
       include_tasks: install-source.yml
-      when: release_archive.status == 404
-    - name: install paperless-ng from release archive
+      when: paperlessng_install_method == "source"
+
+    - name: install paperless-ngx from release archive
       include_tasks: install-release.yml
-      when: release_archive.status == 200
-    - name: change owner and permissions of paperless-ng
+      when: paperlessng_install_method == "precompiledrelease"
+
+    - name: change owner and permissions of paperless-ngx
       command:
         cmd: "{{ item }}"
         warn: false
@@ -229,9 +223,11 @@
         - "chown -R {{ paperlessng_system_user }}:{{ paperlessng_system_group }} {{ tempdir.path }}"
         - "find {{ tempdir.path }} -type d -exec chmod 0750 {} ;"
         - "find {{ tempdir.path }} -type f -exec chmod 0640 {} ;"
-    - name: move paperless-ng
+
+    - name: move paperless-ngx
       command:
-        cmd: "cp -a {{ tempdir.path }}/paperless-ng/. {{ paperlessng_directory }}"
+        cmd: "cp -a {{ tempdir.path }}/paperless-ngx/. {{ paperlessng_directory }}"
+
     - name: store commit hash of installed version
       copy:
         content: "{{ paperlessng_commit }}"
@@ -239,13 +235,14 @@
         owner: "{{ paperlessng_system_user }}"
         group: "{{ paperlessng_system_group }}"
         mode: "0440"
+        
     - name: remove temporary directory
       file:
         path: "{{ tempdir.path }}"
         state: absent
   when: not reconfigure_only
 
-- name: create paperless-ng directories and set permissions
+- name: create paperless-ngx directories and set permissions
   file:
     path: "{{ item }}"
     state: directory
@@ -254,18 +251,27 @@
     mode: "750"
   when: item
   with_items:
-    - "{{ paperlessng_consumption_dir }}"
     - "{{ paperlessng_data_dir }}"
     - "{{ paperlessng_trash_dir }}"
     - "{{ paperlessng_media_root }}"
     - "{{ paperlessng_staticdir }}"
+    - "{{ paperlessng_export_dir }}"
+
+- name: create paperless-ngx consumption directory and set permissions
+  file:
+    path: "{{ paperlessng_consumption_dir }}"
+    state: directory
+    owner: "{{ paperlessng_system_user }}"
+    group: "{{ paperlessng_system_group }}"
+    mode: "750"
+  when: consumption_mount_exist == false
 
 - name: rename initial config
   command:
     cmd: "mv -f {{ paperlessng_directory }}/paperless.conf {{ paperlessng_directory }}/paperless.conf.template"
     removes: "{{ paperlessng_directory }}/paperless.conf"
 
-- name: configure paperless-ng
+- name: configure paperless-ngx
   lineinfile:
     path: "{{ paperlessng_directory }}/paperless.conf.template"
     regexp: "^#?{{ item.regexp }}="
@@ -277,6 +283,8 @@
     # Paths and folders
     - regexp: PAPERLESS_CONSUMPTION_DIR
       line: "PAPERLESS_CONSUMPTION_DIR={{ paperlessng_consumption_dir }}"
+    - regexp: PAPERLESS_EXPORT_DIR
+      line: "PAPERLESS_EXPORT_DIR={{ paperlessng_export_dir }}"
     - regexp: PAPERLESS_DATA_DIR
       line: "PAPERLESS_DATA_DIR={{ paperlessng_data_dir }}"
     - regexp: PAPERLESS_TRASH_DIR
@@ -306,6 +314,8 @@
       line: "PAPERLESS_COOKIE_PREFIX={{ paperlessng_cookie_prefix }}"
     - regexp: PAPERLESS_ENABLE_HTTP_REMOTE_USER
       line: "PAPERLESS_ENABLE_HTTP_REMOTE_USER={{ paperlessng_enable_http_remote_user }}"
+    - regexp: PAPERLESS_URL
+      line: "PAPERLESS_URL={{ paperlessng_url }}"
     # OCR settings
     - regexp: PAPERLESS_OCR_LANGUAGE
       line: "PAPERLESS_OCR_LANGUAGE={{ paperlessng_ocr_languages | join('+') | replace('-','_') }}"
@@ -361,9 +371,11 @@
       line: "PAPERLESS_THUMBNAIL_FONT_NAME={{ paperlessng_thumbnail_font_name }}"
     - regexp: PAPERLESS_IGNORE_DATES
       line: "PAPERLESS_IGNORE_DATES={{ paperlessng_ignore_dates }}"
+    - regexp: PAPERLESS_ENABLE_UPDATE_CHECK
+      line: "PAPERLESS_ENABLE_UPDATE_CHECK={{ paperlessng_enable_update_check }}"
   no_log: yes
 
-- name: configure paperless-ng database [sqlite]
+- name: configure paperless-ngx database [sqlite]
   lineinfile:
     path: "{{ paperlessng_directory }}/paperless.conf.template"
     regexp: "^#?PAPERLESS_DBHOST=(.*)$"
@@ -371,7 +383,7 @@
     backrefs: yes
   when: paperlessng_db_type == 'sqlite'
 
-- name: configure paperless-ng database [postgresql]
+- name: configure paperless-ngx database [postgresql]
   lineinfile:
     path: "{{ paperlessng_directory }}/paperless.conf.template"
     regexp: "^#?{{ item.regexp }}="
@@ -392,7 +404,7 @@
   when: paperlessng_db_type == 'postgresql'
   no_log: yes
 
-- name: deploy paperless-ng configuration
+- name: deploy paperless-ngx configuration
   copy:
     src: "{{ paperlessng_directory }}/paperless.conf.template"
     remote_src: yes
@@ -511,6 +523,15 @@
     option: "ExecStart"
     value: "{{ paperlessng_virtualenv }}/bin/python3 manage.py document_consumer"
 
+- name: remove redis from paperless-consumer service if external
+  ini_file:
+    path: "{{ paperlessng_directory }}/scripts/paperless-consumer.service"
+    section: "Unit"
+    option: "Requires"
+    value: "redis.service"
+    state: absent
+  when: paperlessng_redis_host != 'localhost' or paperlessng_redis_host != '127.0.0.1'
+
 - name: configure paperless-scheduler service
   ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-scheduler.service"
@@ -518,12 +539,64 @@
     option: "ExecStart"
     value: "{{ paperlessng_virtualenv }}/bin/python3 manage.py qcluster"
 
+- name: remove redis from paperless-scheduler service if external
+  ini_file:
+    path: "{{ paperlessng_directory }}/scripts/paperless-scheduler.service"
+    section: "Unit"
+    option: "Requires"
+    value: "redis.service"
+    state: absent
+  when: paperlessng_redis_host != 'localhost' or paperlessng_redis_host != '127.0.0.1'
+
 - name: configure paperless-webserver service
   ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-webserver.service"
     section: "Service"
     option: "ExecStart"
     value: "{{ paperlessng_virtualenv }}/bin/gunicorn -c {{ paperlessng_directory }}/gunicorn.conf.py paperless.asgi:application"
+
+- name: remove redis from paperless-webserver service if external
+  ini_file:
+    path: "{{ paperlessng_directory }}/scripts/paperless-webserver.service"
+    section: "Unit"
+    option: "Requires"
+    value: "redis.service"
+    state: absent
+  when: paperlessng_redis_host != 'localhost' or paperlessng_redis_host != '127.0.0.1'
+
+- name: NFS utility present for redhat-like
+  ansible.builtin.yum:
+    name:
+      - nfs-utils
+      - nfs4-acl-tools
+    state: present
+  when: ansible_os_family == "RedHat" and paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True"
+
+- name: NFS utility present for debian-like
+  ansible.builtin.apt:
+    name:
+      - nfs-common
+      - nfs4-acl-tools
+    state: present
+  when: ansible_os_family == "Debian" and paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True"
+
+- name: Check consumption mountpoint exists
+  ansible.builtin.file:
+    path: "{{ paperlessng_consumption_dir }}"
+    state: directory
+    mode: "{{ paperlessng_consumption_dir_permission }}"
+    owner: root
+    group: root
+  when: paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True" and consumption_mount_exist == 'false'
+
+- name: Mount consumption share
+  ansible.posix.mount:
+    src: "{{ paperlessng_consumption_dir_nfs }}"
+    path: "{{ paperlessng_consumption_dir }}"
+    fstype: nfs
+    opts: "{{ paperlessng_consumption_dir_myopts }}"
+    state: mounted
+  when: paperlessng_consumption_dir_nfs_enabled and paperlessng_is_lxc != "True"
 
 - name: copy systemd services
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
       - build-essential
       - python3-setuptools
       - python3-wheel
+      - git
 
 # upstream virtualenv in Ubuntu 20.04 is broken
 # https://github.com/pypa/virtualenv/issues/1873
@@ -163,8 +164,8 @@
 - name: register current state
   set_fact:
     fresh_installation: '{{ not paperlessng_current_commitfile.stat.exists }}'
-    update_installation: false
-    reconfigure_only: false
+    update_installation: true
+    reconfigure_only: true
 
 - name: register current existing state
   set_fact:
@@ -421,6 +422,15 @@
     cmd: "python3 -m virtualenv {{ paperlessng_virtualenv }} -p /usr/bin/python3"
     creates: "{{ paperlessng_virtualenv }}"
   register: venv
+
+- name: install latest pip
+  become: yes
+  become_user: "{{ paperlessng_system_user }}"
+  pip:
+    name: pip
+    executable: "{{ paperlessng_virtualenv }}/bin/pip3"
+    state: latest
+  when: not reconfigure_only
 
 - block:
     - name: install paperlessng requirements


### PR DESCRIPTION
I know there is already a very similar PR but below I will list changes and features added.  Have renamed all the comments/directories that mention `paperless-ng` to `paperless-nix`

* Renamed all the comments/directories that mention `paperless-ng` to `paperless-ngx` [Note: Variables are still not updated to ngx
* Added paperless export directory
* Added NFS mount possibilities for external consumption directory [if using an LXC container please make the relevant changes to allow the LXC to use NFS]
* Added Tika/Gotenburg endpoint variable
* Added step to upgrade pip within virtualenv prior to running the install of requirements [This is because if the step to upgrade]

Currently working with v1.8.0