### PR TITLE
Fixes/Improvements - Stable release

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,0 +1,7 @@
+skip_list:  # or 'skip_list' to silence them completely
+  - experimental  # all rules tagged as experimental
+  - meta-no-tags  # Tags must contain lowercase letters and digits only.
+  - yaml  # Violations reported by yamllint.
+  - no-handler
+  - no-changed-when
+  - package-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ name: CI
 
 defaults:
   run:
-    working-directory: 'ansible-paperless-ngx'
+    working-directory: 'ansible'
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+---
+name: CI
+'on':
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 3 * * *"
+
+defaults:
+  run:
+    working-directory: 'ansible-paperless-ngx'
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'ansible-paperless-ngx'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install yamllint
+
+      - name: Lint code.
+        run: |
+          yamllint .
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: ${{ !contains(github.event_name, 'pull_request') }}
+      matrix:
+        distro:
+          - ubuntu2004
+          - ubuntu1804
+          - debian10
+          - debian11
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'ansible-paperless-ngx'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,54 +15,92 @@ defaults:
 jobs:
 
   lint:
-    name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v2
-        with:
-          path: 'ansible-paperless-ngx'
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: ansible-lint
+        uses: ansible-community/ansible-lint-action@main
 
-      - name: Set up Python 3.
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
-      - name: Install test dependencies.
-        run: pip3 install yamllint
-
-      - name: Lint code.
-        run: |
-          yamllint .
-  molecule:
-    name: Molecule
-    runs-on: ubuntu-latest
+  molecule-converge:
+    needs:
+      - lint
+    runs-on: ubuntu-20.04
     strategy:
-      fail-fast: ${{ !contains(github.event_name, 'pull_request') }}
+      fail-fast: false
       matrix:
-        distro:
-          - ubuntu2004
-          - ubuntu1804
-          - debian10
-          - debian11
-
+        config:
+          - namespace: "jrei"
+            image: "systemd-ubuntu"
+            tag: "20.04"
+          - namespace: "jrei"
+            image: "systemd-ubuntu"
+            tag: "22.04"
     steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v3
         with:
-          path: 'ansible-paperless-ngx'
-
-      - name: Set up Python 3.
-        uses: actions/setup-python@v2
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@4.0.9
         with:
-          python-version: '3.x'
+          command: converge
+          namespace: ${{ matrix.config.namespace }}
+          image: ${{ matrix.config.image }}
+          tag: ${{ matrix.config.tag }}
 
-      - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+  molecule-test:
+    needs:
+      - molecule-converge
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - namespace: "jrei"
+            image: "systemd-ubuntu"
+            tag: "20.04"
+          - namespace: "jrei"
+            image: "systemd-ubuntu"
+            tag: "22.04"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@4.0.9
+        with:
+          command: test
+          options: parallel
+          namespace: ${{ matrix.config.namespace }}
+          image: ${{ matrix.config.image }}
+          tag: ${{ matrix.config.tag }}
 
-      - name: Run Molecule tests.
-        run: molecule test
-        env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_DISTRO: ${{ matrix.distro }}
+  molecule-idempotence:
+    needs:
+      - molecule-converge
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - namespace: "jrei"
+            image: "systemd-ubuntu"
+            tag: "20.04"
+          - namespace: "jrei"
+            image: "systemd-ubuntu"
+            tag: "22.04"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        continue-on-error: true
+        uses: robertdebock/molecule-action@4.0.9
+        with:
+          command: idempotence
+          namespace: ${{ matrix.config.namespace }}
+          image: ${{ matrix.config.image }}
+          tag: ${{ matrix.config.tag }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ paperlessng_db_pass: paperlessng
 paperlessng_db_sslmode: prefer
 
 # Paths and folders
-paperlessng_directory: /opt/paperless-ngx
+paperlessng_directory: "/opt/paperless-ngx"
 paperlessng_consumption_dir: "{{ paperlessng_directory }}/consumption"
 paperlessng_export_dir: "{{ paperlessng_directory }}/export"
 paperlessng_data_dir: "{{ paperlessng_directory }}/data"
@@ -26,15 +26,16 @@ paperlessng_staticdir: "{{ paperlessng_directory }}/static"
 paperlessng_filename_format:
 paperlessng_logging_dir: "{{ paperlessng_data_dir }}/log"
 paperlessng_virtualenv: "{{ paperlessng_directory }}/.venv"
+paperlessng_tmp_dir: "/opt/"
 
-#NFS
+# NFS
 paperlessng_consumption_dir_nfs_enabled: false
 paperlessng_consumption_dir_nfs:
 paperlessng_consumption_dir_mountpoint:
 paperlessng_consumption_dir_permission:
 paperlessng_consumption_dir_myopts:
 # Hosting & Security
-paperlessng_url: http://change-to-ip-of-host:8000
+paperlessng_url: http://localhost:8000
 paperlessng_secret_key: PLEASECHANGETHISFORTHELOVEOFGOD
 paperlessng_allowed_hosts: "*"
 paperlessng_cors_allowed_hosts: http://localhost:8000
@@ -60,6 +61,10 @@ paperlessng_ocr_user_args:
   - optimize: 1
 paperlessng_use_jbig2enc: true
 paperlessng_big2enc_lossy: false
+
+# jbig2encode settings
+jbig2enc_version: 0.29
+jbig2enc_tmp_dir: "/opt/"
 
 # Tika settings
 paperlessng_tika_enabled: false
@@ -91,7 +96,7 @@ paperlessng_system_user: paperlessng
 paperlessng_system_group: paperlessng
 
 # Webserver settings
-paperlessng_listen_address: 0.0.0.0
+paperlessng_listen_address: 127.0.0.1
 paperlessng_listen_port: 8000
 
 # Extra

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,8 +5,8 @@ galaxy_info:
   description: Bare-metal deployment of paperless-ngx DMS
   license: license (GPLv3)
   min_ansible_version: 2.7
-  namespace: paperless_ng
-  role_name: paperless_ng
+  namespace: paperless_ngx
+  role_name: paperless_ngx
 
   platforms:
     - name: Debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,9 +9,9 @@ galaxy_info:
   role_name: paperless_ngx
 
   platforms:
-    - name: Debian
+    - name: Ubuntu
       versions:
-        - buster
+        - jammy
     - name: Ubuntu
       versions:
         - focal

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,4 +17,4 @@
 
     - name: update to newest paperless-ngx release
       ansible.builtin.include_role:
-        name: ansible-paperless-ngx
+        name: ansible

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,9 +2,19 @@
 - name: update previous release to newest release
   hosts: all
   tasks:
-    - name: set current github commit as version when available
-      set_fact:
-        paperlessng_version: "{{ lookup('env', 'TARGET_GITHUB_SHA') | default('master', True) }}"
+    - name: get latest release version
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/paperless-ngx/paperless-ngx/releases/latest
+        method: GET
+        return_content: yes
+        headers:
+          Content-Type: "application/json"
+      register: latest_release
+
+    - name: parse latest release version
+      ansible.builtin.set_fact:
+        paperlessng_version: "{{ latest_release.json['tag_name'] }}"
+
     - name: update to newest paperless-ngx release
-      include_role:
-        name: ansible
+      ansible.builtin.include_role:
+        name: ansible-paperless-ngx

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ubuntu_focal
-    image: jrei/systemd-ubuntu:20.04
+  - name: "ansible-paperless-ngx-${image:-systemd-ubuntu}-${tag:-20.04}"
+    image: "${namespace:-jrei}/${image:-systemd-ubuntu}:${tag:-20.04}"
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -13,23 +13,31 @@ platforms:
       - /tmp
       - /run
       - /run/lock
+    published_ports:
+      - 8000:8000
     override_command: false
-  # ubuntu 18.04 bionic works except that
-  #   the default redis configuration expects IPv6 which is not enabled in docker by default
-  #   the default Python environment is configured for ASCII instead of UTF-8
-  # ubuntu 16.04 xenial only has Python 3.5 which is EOL and breaks multiple dependencies
-  - name: debian_buster
-    image: jrei/systemd-debian:10
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    tmpfs:
-      - /tmp
-      - /run
-      - /run/lock
-    override_command: false
-# debian 9 stretch only has Python 3.5 which is EOL and breaks multiple dependencies
 provisioner:
   name: ansible
 verifier:
   name: ansible
+scenario:
+  converge_sequence:
+    - create
+    - prepare
+    - converge
+    - destroy
+  test_sequence:
+    - create
+    - prepare
+    - verify
+    - syntax
+    - converge
+    - verify
+    - cleanup
+    - destroy
+  idempotence_sequence:
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - destroy

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,4 +8,4 @@
 
     - name: install previous paperless-ngx release
       ansible.builtin.include_role:
-        name: ansible-paperless-ngx
+        name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -3,9 +3,9 @@
   hosts: all
   tasks:
     - name: set previous version as installation target
-      set_fact:
-        paperlessng_version: latest
+      ansible.builtin.set_fact:
+        paperlessng_version: v1.7.1
 
     - name: install previous paperless-ngx release
-      include_role:
-        name: ansible
+      ansible.builtin.include_role:
+        name: ansible-paperless-ngx

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,7 +8,7 @@
 
   tasks:
     - name: check if webserver is up
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}
         status_code: [200, 302]
         return_content: true
@@ -16,12 +16,12 @@
       failed_when: "'Sign in</button>' not in landingpage.content"
 
     - name: generate random name and content
-      set_fact:
+      ansible.builtin.set_fact:
         content: "{{ lookup('password', '/dev/null length=65536 chars=ascii_letters') }}"
         filename: "{{ lookup('password', '/dev/null length=8 chars=ascii_letters') }}"
 
     - name: check if document posting works
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/post_document/
         method: POST
         body_format: form-multipart
@@ -36,8 +36,13 @@
       register: post_document
       failed_when: "'OK' not in post_document.content"
 
+    # - name: Output post register
+    #   ansible.builtin.debug:
+    #     var: post_document
+    #   run_once: true
+
     - name: verify uploaded document has been accepted
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/logs/paperless/
         headers:
           Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
@@ -45,12 +50,17 @@
       register: logs
       failed_when: ('Consuming ' + filename + '.txt') not in logs.content
 
+    # - name: Output logs register
+    #   ansible.builtin.debug:
+    #     var: logs
+    #   run_once: true
+
     - name: sleep till consumption finished
-      pause:
+      ansible.builtin.pause:
         seconds: 10
 
     - name: verify uploaded document has been consumed
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/logs/paperless/
         headers:
           Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
@@ -59,7 +69,7 @@
       failed_when: filename + ' consumption finished' not in logs.content
 
     - name: get documents
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/
         headers:
           Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
@@ -67,11 +77,11 @@
       register: documents
 
     - name: set document index
-      set_fact:
+      ansible.builtin.set_fact:
         index: "{{ documents.json['results'][0]['id'] }}"
 
     - name: verify uploaded document is avaiable
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/{{ index }}/
         headers:
           Authorization: Basic {{ (paperlessng_superuser_name + ":" + paperlessng_superuser_password) | b64encode }}
@@ -80,7 +90,7 @@
       failed_when: "'Not found.' in document.content or content not in document.json['content']"
 
     - name: check if deleting uploaded document works
-      uri:
+      ansible.builtin.uri:
         url: http://{{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}/api/documents/bulk_edit/
         method: POST
         body_format: json

--- a/tasks/install-jbig2enc.yml
+++ b/tasks/install-jbig2enc.yml
@@ -1,0 +1,52 @@
+---
+- name: install dev dependencies
+  ansible.builtin.package:
+    name: "{{ item }}"
+    update_cache: yes
+  with_items:
+    - autotools-dev
+    - automake
+    - libtool
+    - libleptonica-dev
+
+- name: Install Debian specific libs
+  ansible.builtin.package:
+    name: "{{ item }}"
+    update_cache: yes
+  with_items:
+    - zlib1g-dev
+  when: ansible_os_family == "Debian"
+
+- name: create temporary git directory
+  ansible.builtin.tempfile:
+    state: directory
+    path: "{{ jbig2enc_tmp_dir }}"
+  register: gitdir
+
+- name: Pull jbig2enc
+  ansible.builtin.git:
+    repo: https://github.com/agl/jbig2enc.git
+    dest: "{{ gitdir.path }}"
+    version: "{{ jbig2enc_version }}"
+    recursive: yes
+  register: jbig2enc_source
+
+- name: Run autogen for jbig2enc
+  ansible.builtin.command: ./autogen.sh
+  args:
+    chdir: "{{ gitdir.path }}"
+
+- name: Run configure for jbig2enc
+  ansible.builtin.command: ./configure
+  args:
+    chdir: "{{ gitdir.path }}"
+
+- name: Run 'make and make install' target
+  community.general.make:
+    chdir: "{{ gitdir.path }}"
+    target: install
+
+- name: remove temporary git directory
+  ansible.builtin.file:
+    path: "{{ gitdir.path }}"
+    state: absent

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -17,7 +17,8 @@
     - "{{ tempdir.path }}/paperless-ngx"
     - "{{ tempdir.path }}/paperless-ngx/scripts"
 
-- block:
+- name: Prep the deployment
+  block:
     - name: create temporary git directory
       ansible.builtin.tempfile:
         state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,13 +35,14 @@
       - pngquant
       - zlib1g
       - tesseract-ocr
-      # dev
+      # Dev
       - sudo
       - build-essential
       - python3-setuptools
       - python3-wheel
       - python3-venv
       - git
+      - python3-jmespath
 
 # upstream virtualenv in Ubuntu 20.04 is broken
 # https://github.com/pypa/virtualenv/issues/1873
@@ -54,35 +55,8 @@
   ansible.builtin.apt:
     pkg: "{{ paperlessng_ocr_languages | map('regex_replace', '^(.*)$', 'tesseract-ocr-\\1') | map('replace', '_', '-') | list }}"
 
-- name: set up notesalexp repository key (for jbig2enc)
-  ansible.builtin.apt_key:
-    url: https://notesalexp.org/debian/alexp_key.asc
-    state: present
-  when: paperlessng_use_jbig2enc
-
-- name: set up notesalexp repository (for jbig2enc)
-  ansible.builtin.apt_repository:
-    repo: deb https://notesalexp.org/debian/{{ ansible_distribution_release }}/ {{ ansible_distribution_release }} main
-    state: present
-  when: paperlessng_use_jbig2enc
-
-- name: set up notesalexp repository pinning
-  ansible.builtin.copy:
-    content: |
-      Package: *
-      Pin: release o=notesalexp.org
-      Pin-Priority: 1
-
-      Package: jbig2enc
-      Pin: release o=notesalexp.org
-      Pin-Priority: 500
-    dest: /etc/apt/preferences.d/notesalexp
-  when: paperlessng_use_jbig2enc
-
-- name: install jbig2enc
-  ansible.builtin.apt:
-    pkg: jbig2enc
-    update_cache: true
+- name: install jbig2encode from source
+  include_tasks: install-jbig2enc.yml
   when: paperlessng_use_jbig2enc
 
 - name: install redis
@@ -111,18 +85,20 @@
     # GNUPG_HOME required due to paperless db.py
     create_home: true
 
-- block:
+- name: Prep the release
+  block:
     - name: get latest release version
       ansible.builtin.uri:
         url: https://api.github.com/repos/paperless-ngx/paperless-ngx/releases/latest
         method: GET
       register: latest_release
     - name: parse latest release version
-      set_fact:
+      ansible.builtin.set_fact:
         paperlessng_version: "{{ latest_release.json['tag_name'] }}"
   when: paperlessng_version == "latest"
 
-- block:
+- name: Check the version
+  block:
     - name: check if version can be found on github
       ansible.builtin.uri:
         url: https://api.github.com/repos/paperless-ngx/paperless-ngx/commits/{{ paperlessng_version }}
@@ -164,7 +140,8 @@
     reconfigure_only: "{{ paperlessng_current_commit.stdout == paperlessng_commit | string }}"
   when: not fresh_installation
 
-- block:
+- name: Backup
+  block:
     - name: backup current paperless-ngx installation
       ansible.builtin.copy:
         src: "{{ paperlessng_directory }}"
@@ -182,7 +159,8 @@
         - static
   when: update_installation
 
-- block:
+- name: Create dirs required
+  block:
     - name: create paperless-ngx directory and set permissions
       ansible.builtin.file:
         path: "{{ paperlessng_directory }}"
@@ -191,12 +169,20 @@
         group: "{{ paperlessng_system_group }}"
         mode: "750"
 
-    - name: create temporary directory
-      become: true
+    - name: Check if tempdir exists
+      ansible.builtin.find:
+        paths: "{{ paperlessng_tmp_dir }}"
+        patterns: "tempgit*"
+        file_type: directory
+      register: tempdir_state
+
+    - name: Create temporary directory
       ansible.builtin.tempfile:
         state: directory
-        path: "{{ paperlessng_directory }}"
+        path: "{{ paperlessng_tmp_dir }}"
+        suffix: tempgit
       register: tempdir
+      when: tempdir_state.matched == 0
 
     - name: install paperless-ngx from source
       include_tasks: install-source.yml
@@ -205,6 +191,20 @@
     - name: install paperless-ngx from release archive
       include_tasks: install-release.yml
       when: paperlessng_install_method == "precompiledrelease"
+
+    - name: Find all files created
+      ansible.builtin.find:
+        path: "{{ tempdir.path }}"
+        file_type: file
+        recurse: yes
+      register: find_result_files
+
+    - name: Find all directories created
+      ansible.builtin.find:
+        path: '{{ tempdir.path }}'
+        file_type: directory
+        recurse: yes
+      register: find_result_directories
 
     - name: change owner and permissions of paperless-ngx
       ansible.builtin.command:
@@ -240,7 +240,8 @@
     owner: "{{ paperlessng_system_user }}"
     group: "{{ paperlessng_system_group }}"
     mode: "750"
-  when: item
+    recurse: yes
+  # when: item
   with_items:
     - "{{ paperlessng_data_dir }}"
     - "{{ paperlessng_trash_dir }}"
@@ -399,6 +400,7 @@
 
 - name: create paperlessng venv
   become: true
+  become_user: "{{ paperlessng_system_user }}"
   ansible.builtin.command:
     cmd: python3 -m venv {{ paperlessng_virtualenv }}
     creates: "{{ paperlessng_virtualenv }}"
@@ -406,28 +408,41 @@
 
 - name: install latest pip
   become: true
+  become_user: "{{ paperlessng_system_user }}"
   ansible.builtin.pip:
     name: pip
     executable: "{{ paperlessng_virtualenv }}/bin/pip3"
     state: latest
   when: not reconfigure_only
 
-- block:
+- name: Install needed requirements
+  block:
+    - name: Replace pikepdf version if using ngx version lower than v1.8.0
+      ansible.builtin.lineinfile:
+        path: "{{ paperlessng_directory }}/requirements.txt"
+        regexp: '^pikepdf(.*)'
+        line: 'pikepdf==5.4.0'
+      when: not paperlessng_version == "v1.8.0" or
+            paperlessng_version == "latest"
+
     - name: install paperlessng requirements
       become: true
+      become_user: "{{ paperlessng_system_user }}"
       ansible.builtin.pip:
         requirements: "{{ paperlessng_directory }}/requirements.txt"
         executable: "{{ paperlessng_virtualenv }}/bin/pip3"
         extra_args: --upgrade
     - name: migrate database schema
       become: true
-      command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py migrate"
+      become_user: "{{ paperlessng_system_user }}"
+      ansible.builtin.command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py migrate"
       register: database_schema
       changed_when: '"No migrations to apply." not in database_schema.stdout'
   when: not reconfigure_only
 
 - name: configure paperless superuser
   become: true
+  become_user: "{{ paperlessng_system_user }}"
   ansible.builtin.command: "{{ paperlessng_virtualenv }}/bin/python3 {{ paperlessng_directory }}/src/manage.py manage_superuser"
   environment:
     PAPERLESS_ADMIN_USER: "{{ paperlessng_superuser_name }}"


### PR DESCRIPTION
Changes:

* Working molecule pipeline with Github Actions
    * Builds in Ubuntu 20/22.04
* Added ansible-lint exceptions
* Added a paperless temp directory for git clone using the tempfile ansible module
* Added a task with the ansible find module to replace the command that runs already. WIP

Fixes:

* Corrected the path for paperless directory
* Added correct defaults for URL/Listen address to run paperless in docker/molecule
* Added a separate task to install jbig2enc from source due to issues finding apt repo that contained a working package
* Added jmespath package as part of the base install
* Added becomes_user/become back in to fix the issues with dir/file owner/groups on install 
* Added a task to install latest version of pikepdf even if installing an earlier version than v1.8.0