### PR TITLE
Make installation of jbig2enc idempotent

### DIFF
--- a/files/jbig2enc-0.29-fix-reported-version.patch
+++ b/files/jbig2enc-0.29-fix-reported-version.patch
@@ -1,0 +1,18 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,5 +1,5 @@
+ AC_PREREQ(2.50)
+-AC_INIT([jbig2enc], [0.28], [agl@imperialviolet.org], [jbig2enc-0.28],
++AC_INIT([jbig2enc], [0.29], [agl@imperialviolet.org], [jbig2enc-0.29],
+ 		[https://github.com/agl/jbig2enc])
+ AC_CONFIG_MACRO_DIR([m4])
+ AM_INIT_AUTOMAKE([-Wall -Werror foreign no-dependencies])
+@@ -13,7 +13,7 @@
+ 
+ # Release versioning
+ GENERIC_MAJOR_VERSION=0
+-GENERIC_MINOR_VERSION=28
++GENERIC_MINOR_VERSION=29
+ GENERIC_MICRO_VERSION=0
+ 
+ # API version (often = GENERIC_MAJOR_VERSION.GENERIC_MINOR_VERSION)

--- a/tasks/install-jbig2enc.yml
+++ b/tasks/install-jbig2enc.yml
@@ -31,6 +31,13 @@
     recursive: yes
   register: jbig2enc_source
 
+- name: apply patch to fix reported version
+  ansible.posix.patch:
+    basedir: "{{ gitdir.path }}"
+    src: jbig2enc-0.29-fix-reported-version.patch
+    strip: 1
+    state: present
+
 - name: Run autogen for jbig2enc
   ansible.builtin.command: ./autogen.sh
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,8 +55,21 @@
   ansible.builtin.apt:
     pkg: "{{ paperlessng_ocr_languages | map('regex_replace', '^(.*)$', 'tesseract-ocr-\\1') | map('replace', '_', '-') | list }}"
 
-- name: install jbig2encode from source
-  include_tasks: install-jbig2enc.yml
+- name: install jbig2enc
+  block:
+    - name: check if jbig2enc is already installed with correct version
+      ansible.builtin.command:
+        cmd: jbig2 --version
+      changed_when:
+        jbig2enc_version_installed.rc != 0 or
+        (jbig2enc_version_installed.stderr.split(' ')[-1] != jbig2enc_version | string) | default(true)
+      failed_when: false
+      ignore_errors: true
+      register: jbig2enc_version_installed
+
+    - name: install jbig2encode from source
+      include_tasks: install-jbig2enc.yml
+      when: jbig2enc_version_installed.changed
   when: paperlessng_use_jbig2enc
 
 - name: install redis


### PR DESCRIPTION
Currently, jbig2enc is built from source unconditionally every time the role is executed. This PR adds a check to avoid pulling and compiling if the correct version is already installed.
This is achieved by running `jbig2 --version` on the target system. Only if the output reports the wrong version or if the command fails (i.e. no jbig2enc is installed at all), the task file to build and install it is included.

After adding this check, I noticed that the current version (0.29) happens to report its version incorrectly as `0.28`. Since the repo didn't see any activity in the last four years, I do not expect a new upstream release any time soon to fix that. Thus, this PR also adds a patch that is applied after pulling version 0.29 to fix the reported version.
This is a rather hackish workaround, but it's the best I could come up with. An alternative would be to accept the output `0.28` even if 0.29 is requested in `jbig2enc_version`, but that would also accept the "real" version 0.28 and thus the wrong one.