### PR TITLE
style(lint): Add pre-commit setup and yamllint

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,7 +1,9 @@
+---
 skip_list:  # or 'skip_list' to silence them completely
   - experimental  # all rules tagged as experimental
   - meta-no-tags  # Tags must contain lowercase letters and digits only.
   - yaml  # Violations reported by yamllint.
+  - name[casing] # Code is mainly using lower case names
   - no-handler
   - no-changed-when
   - package-latest

--- a/.config/yamllint.yml
+++ b/.config/yamllint.yml
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  # ToDo: Change severity of rules back to error with a later PR
+  braces:
+    level: warning
+  hyphens:
+    level: warning
+  line-length:
+    level: warning
+    max: 180
+  new-line-at-end-of-file:
+    level: warning

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/checkout@v3
       - name: ansible-lint
         uses: ansible-community/ansible-lint-action@main
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .config/yamllint.yml
+          format: github
 
   molecule-converge:
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
+        args: ["-c=.config/yamllint.yml", "."]
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v6.8.0
+    hooks:
+      - id: ansible-lint
+        files: \.(yaml|yml)$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## How to contribute to this ansible role
+### (Optional) Install 'pre-commit' dependency
+
+To enable automatic checks (like code linting) beforey each commit it is advised (but no must) to install ***pre-commit***:
+
+Install it to your environment: 
+
+`~/ansible$ pip install pre-commit` (for more options see [here](https://pre-commit.com/#installation))
+
+Enable pre-commit within the repo: 
+
+`~/ansible$ pre-commit install`
+
+(Optional) Run complete check once: 
+
+`~/ansible$ pre-commit run --all-files`

--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ Example Playbook
         paperlessng_listen_address: 0.0.0.0
         paperlessng_listen_port: 8000
 ```
+
+## Contributing
+We encourage you to contribute to this role! Please check out the
+[contributing guide](CONTRIBUTING.md) for guidelines about how to proceed.


### PR DESCRIPTION
In order to support early failings on linting errors during local
development a pre-commit ability was introduced. When making use of it
it will enforce linting rules before every commit so that in the future
less builds will fail because of linting errors. Additionally yamllint
was introduced for local and remote setup. To get a more harmonized code
base in the future. Yamllint configuration was set to defaults that
respect the actual unharmonized code base but will throw warnings to
remind us of the isseu ;) Rules can be made more restrictive in the
future e.g. if no other PRs are open at the same time.