### PR TITLE
refactor: Use a var to determine role name to include

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,4 +17,4 @@
 
     - name: update to newest paperless-ngx release
       ansible.builtin.include_role:
-        name: ansible
+        name: "{{ molecule_role_inclusion_name }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,8 @@ platforms:
     override_command: false
 provisioner:
   name: ansible
+  options:
+    extra-vars: "{'molecule_role_inclusion_name': \"{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}\" }"
 verifier:
   name: ansible
 scenario:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,4 +8,4 @@
 
     - name: install previous paperless-ngx release
       ansible.builtin.include_role:
-        name: ansible
+        name: "{{ molecule_role_inclusion_name }}"


### PR DESCRIPTION
As the repo and role is called 'ansible' it quickly gets confusing if ones uses custom fork names or just a custom parent dir to make it more obvious what this role is for. A workaround is to substitute the role name by path.

example:
```
$ git clone https://github.com/paperless-ngx/ansible.git
$ mv ansible ansible_paperless_ngx
$ cd ansible_paperless_nxg
$ ansible_paperless_ngx$ molecule test
```
^-------- fails because the role "ansible" will not be found if the parent dir is called a more obvious way like ansible_paperless_ngx