### PR TITLE
fix(service units): change mode to world accessible (644)

### DIFF
--- a/tasks/paperless_ngx/systemd_services.yml
+++ b/tasks/paperless_ngx/systemd_services.yml
@@ -58,7 +58,7 @@
     src: "{{ paperless_ngx_dir_installation }}/scripts/{{ item.name }}"
     remote_src: true
     dest: /etc/systemd/system/{{ item.name }}
-    mode: 0640
+    mode: 0644
   loop: "{{ paperless_ngx_services_list }}"
   notify: Restart paperless completely
 


### PR DESCRIPTION
otherwise there will appear warnings in the syslog that these service
units are world-inaccessable.