### PR TITLE
test: add distro as dimension to GH actions matrix

### DIFF
--- a/.github/workflows/code_testing.yml
+++ b/.github/workflows/code_testing.yml
@@ -23,6 +23,11 @@ jobs:
   molecule_test:
     strategy:
       matrix:
+        distro:
+          - debian11
+          # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
+          # - ubuntu2204
+          - ubuntu2004
         molecule_scenario: [
           alternative_installation,
           check_fails,
@@ -78,4 +83,5 @@ jobs:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           TEST_MOLECULE_LINT: false
+          TEST_MOLECULE_DISTRO: ${{ matrix.distro }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,6 +1,5 @@
 ansible
 ansible-lint
 colorama
-docker
-molecule[docker]
+molecule-plugins[docker]
 yamllint

--- a/molecule/alternative_installation/molecule.yml
+++ b/molecule/alternative_installation/molecule.yml
@@ -4,8 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian11
-    image: "geerlingguy/docker-debian11-ansible:latest"
+  - name: instance
+    image: "geerlingguy/docker-${TEST_MOLECULE_DISTRO:-debian11}-ansible:latest"
+    platform: "${TEST_MOLECULE_ARCH:-amd64}"  # ToDo: If GH Actions somewhen supports ARM this can be utilized
     cgroupns_mode: host
     override_command: false
     dockerfile: ../Dockerfile.j2

--- a/molecule/check_fails/molecule.yml
+++ b/molecule/check_fails/molecule.yml
@@ -4,8 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian11
-    image: "geerlingguy/docker-debian11-ansible:latest"
+  - name: instance
+    image: "geerlingguy/docker-${TEST_MOLECULE_DISTRO:-debian11}-ansible:latest"
+    platform: "${TEST_MOLECULE_ARCH:-amd64}"  # ToDo: If GH Actions somewhen supports ARM this can be utilized
     cgroupns_mode: host
     override_command: false
     dockerfile: ../Dockerfile.j2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian11
-    image: "geerlingguy/docker-debian11-ansible:latest"
+  - name: instance
+    image: "geerlingguy/docker-${TEST_MOLECULE_DISTRO:-debian11}-ansible:latest"
+    platform: "${TEST_MOLECULE_ARCH:-amd64}"  # ToDo: If GH Actions somewhen supports ARM this can be utilized
     cgroupns_mode: host
     override_command: false
     dockerfile: ../Dockerfile.j2
@@ -13,24 +14,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: false
-  - name: ubuntu2004
-    image: "geerlingguy/docker-ubuntu2004-ansible:latest"
-    cgroupns_mode: host
-    override_command: false
-    dockerfile: ../Dockerfile.j2
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    pre_build_image: false
-    # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
-    # - name: ubuntu2204
-    #   image: "geerlingguy/docker-ubuntu2204-ansible:latest"
-    #   cgroupns_mode: host
-    #   override_command: false
-    #   volumes:
-    #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    #   privileged: true
-    #   pre_build_image: false
 provisioner:
   name: ansible
   inventory:

--- a/molecule/postgresql_db/molecule.yml
+++ b/molecule/postgresql_db/molecule.yml
@@ -4,8 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian11
-    image: "geerlingguy/docker-debian11-ansible:latest"
+  - name: instance
+    image: "geerlingguy/docker-${TEST_MOLECULE_DISTRO:-debian11}-ansible:latest"
+    platform: "${TEST_MOLECULE_ARCH:-amd64}"  # ToDo: If GH Actions somewhen supports ARM this can be utilized
     cgroupns_mode: host
     override_command: false
     dockerfile: ../Dockerfile.j2

--- a/molecule/reconfigure/molecule.yml
+++ b/molecule/reconfigure/molecule.yml
@@ -4,8 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian11
-    image: "geerlingguy/docker-debian11-ansible:latest"
+  - name: instance
+    image: "geerlingguy/docker-${TEST_MOLECULE_DISTRO:-debian11}-ansible:latest"
+    platform: "${TEST_MOLECULE_ARCH:-amd64}"  # ToDo: If GH Actions somewhen supports ARM this can be utilized
     cgroupns_mode: host
     override_command: false
     dockerfile: ../Dockerfile.j2

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -4,8 +4,9 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: debian11
-    image: "geerlingguy/docker-debian11-ansible:latest"
+  - name: instance
+    image: "geerlingguy/docker-${TEST_MOLECULE_DISTRO:-debian11}-ansible:latest"
+    platform: "${TEST_MOLECULE_ARCH:-amd64}"  # ToDo: If GH Actions somewhen supports ARM this can be utilized
     cgroupns_mode: host
     override_command: false
     dockerfile: ../Dockerfile.j2


### PR DESCRIPTION
After the solution mentioned in https://github.com/ansible-community/molecule/issues/3819 it is now possible to use a matrix parameter that makes it possible to test multiple platforms in parallel without a lot configuration overhead.