### PR TITLE
test(molecule): change molecule version to use >5.0.0

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,4 @@
 ansible==7.5.0
 ansible-lint==6.15.0
-molecule==5.0.1
 pip==23.1.2
 yamllint==1.31.0

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,5 @@
-pip==23.1.2
 ansible==7.5.0
-yamllint==1.31.0
 ansible-lint==6.15.0
+molecule==5.0.1
+pip==23.1.2
+yamllint==1.31.0

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,5 +1,6 @@
 ansible
 ansible-lint
 colorama
+molecule>=5.0.1
 molecule-plugins[docker]
 yamllint


### PR DESCRIPTION
5.0.0 had a bug and is automatically pulled if ansible version is
minimum version