### PR TITLE
fix: Remove elevated privileges for locally delegated tasks

### DIFF
--- a/tasks/preparation/platform.yml
+++ b/tasks/preparation/platform.yml
@@ -28,6 +28,7 @@
       register: _ansible_installed_collections
       delegate_to: localhost
       run_once: true
+      become: false
 
     - name: Loop through all dependencies
       ansible.builtin.fail:
@@ -38,3 +39,4 @@
       run_once: true
       loop: "{{ ansible_required_collections }}"
       register: _exception
+      become: false

--- a/tasks/preparation/pngx_release.yml
+++ b/tasks/preparation/pngx_release.yml
@@ -18,6 +18,7 @@
       register: _latest_release_api_response
       until: _latest_release_api_response.status == 200
       retries: 5
+      become: false
 
     - name: "Set paperless version to {{ _latest_release_api_response.json.tag_name[1:] }}"
       ansible.builtin.set_fact:
@@ -46,6 +47,7 @@
       register: _release_download_uri_response
       until: _release_download_uri_response.status == 200
       retries: 5
+      become: false
 
 - name: Check for existing paperless-ngx version file
   become: true


### PR DESCRIPTION
I have a low privileged user for ansible, so I need to apply the become parameter onto your role, to work properly.
```yaml
- ansible.builtin.include_role:
    name: "paperless_ngx.paperless_ngx"
    apply:
      become: true
```

When I run this, I get an error message stating that a sudo password is required. The password for the target is given, but the task that failes is being delegated to localhost, which means that a password for the ansible machine would be required.
```
TASK [paperless_ngx.paperless_ngx : Get all collections as fact] ******************************************************
fatal: [app -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

This change removes the sudo privileges of four tasks that are being delegated locally) and do not require elevated privileges. This way the role does work for my environment too.