### PR TITLE
fix: do not run tasks in checkmode that require registerd variable

### DIFF
--- a/tasks/base_dependencies/jbig2enc.yml
+++ b/tasks/base_dependencies/jbig2enc.yml
@@ -54,6 +54,8 @@
       until: _jbig2enc_source is succeeded
       retries: 3
       delay: 10
+      when: not ansible_check_mode | bool
+
 
     - name: Apply patch to fix reported version
       ansible.posix.patch:
@@ -61,20 +63,26 @@
         src: jbig2enc-0.29-fix-reported-version.patch
         strip: 1
         state: present
+      when: not ansible_check_mode | bool
 
     - name: Run autogen for jbig2enc
       ansible.builtin.command: ./autogen.sh
       args:
         chdir: "{{ _jbig2enc_gitdir.path }}"
       changed_when: true
+      when: not ansible_check_mode | bool
+
 
     - name: Run configure for jbig2enc
       ansible.builtin.command: ./configure
       args:
         chdir: "{{ _jbig2enc_gitdir.path }}"
       changed_when: true
+      when: not ansible_check_mode | bool
+
 
     - name: Run 'make and make install' target
       community.general.make:
         chdir: "{{ _jbig2enc_gitdir.path }}"
         target: install
+      when: not ansible_check_mode | bool

--- a/tasks/base_dependencies/python.yml
+++ b/tasks/base_dependencies/python.yml
@@ -57,15 +57,18 @@
         - "not 'The read operation timed out' in _download_and_unarchive_python.msg | default('')"
       retries: 3
       delay: 60
+      when: not ansible_check_mode | bool
 
     - name: Run configure for python
       ansible.builtin.command: ./configure --prefix={{ paperless_ngx_dir_python }} --enable-optimizations --with-ensurepip=install
       args:
         chdir: "{{ _python_archive_dir.path }}"
       changed_when: true
+      when: not ansible_check_mode | bool
 
     - name: Run 'make and make altinstall' target
       become: true
       community.general.make:
         chdir: "{{ _python_archive_dir.path }}"
         target: altinstall
+      when: not ansible_check_mode | bool

--- a/tasks/preparation/platform.yml
+++ b/tasks/preparation/platform.yml
@@ -28,6 +28,7 @@
       register: _ansible_installed_collections
       delegate_to: localhost
       run_once: true
+      check_mode: false
 
     - name: Loop through all dependencies
       ansible.builtin.fail:

--- a/tasks/preparation/pngx_release.yml
+++ b/tasks/preparation/pngx_release.yml
@@ -18,6 +18,8 @@
       register: _latest_release_api_response
       until: _latest_release_api_response.status == 200
       retries: 5
+      check_mode: false
+
 
     - name: "Set paperless version to {{ _latest_release_api_response.json.tag_name[1:] }}"
       ansible.builtin.set_fact:
@@ -46,6 +48,8 @@
       register: _release_download_uri_response
       until: _release_download_uri_response.status == 200
       retries: 5
+      check_mode: false
+
 
 - name: Check for existing paperless-ngx version file
   become: true
@@ -64,6 +68,7 @@
       changed_when: _paperless_ngx_version_installed_object.stdout != paperless_ngx_version | string
       # failed_when: false
       # ignore_errors: true
+      when: not ansible_check_mode | bool
 
     - name: Set version of current installation as variable
       ansible.builtin.set_fact:


### PR DESCRIPTION
do not run tasks in checkmode that require registerd variable, run non changing tasks like uri