### PR TITLE
fix: unarchive fails for user id != 1000

### DIFF
--- a/tasks/base_dependencies/python.yml
+++ b/tasks/base_dependencies/python.yml
@@ -36,12 +36,9 @@
         path: "{{ paperless_ngx_dependency_install_tmp_dir }}"
       register: _python_archive_dir
 
-    - name: Pepare permissions of tmp dir for unarchiving python sources
-      ansible.builtin.file:
-        state: directory
-        owner: 1000
-        group: 1000
-        path: "{{ _python_archive_dir.path }}"
+    - name: Debug
+      ansible.builtin.debug:
+        msg: "LURURURURURURU!!!!"
 
     - name: Download and extract python sources
       become: true
@@ -49,8 +46,7 @@
         src: "{{ paperless_ngx_python_release_url }}"
         remote_src: true
         dest: "{{ _python_archive_dir.path }}"
-        extra_opts: [--strip-components=1]
-        owner: "{{ _paperless_ngx_untar_username }}"
+        extra_opts: [--strip-components=1,--no-same-owner]
       register: _download_and_unarchive_python
       until:
         - "not 'urlopen error' in _download_and_unarchive_python.msg | default('')"

--- a/tasks/base_dependencies/python.yml
+++ b/tasks/base_dependencies/python.yml
@@ -36,8 +36,16 @@
         path: "{{ paperless_ngx_dependency_install_tmp_dir }}"
       register: _python_archive_dir
 
+    - name: Pepare permissions of tmp dir for unarchiving python sources
+      ansible.builtin.file:
+        state: directory
+        owner: 1000
+        group: 1000
+        path: "{{ _python_archive_dir.path }}"
+
     - name: Download and extract python sources
       become: true
+      become_user: "{{ _paperless_ngx_untar_username }}"
       ansible.builtin.unarchive:
         src: "{{ paperless_ngx_python_release_url }}"
         remote_src: true

--- a/tasks/base_dependencies/python.yml
+++ b/tasks/base_dependencies/python.yml
@@ -45,12 +45,12 @@
 
     - name: Download and extract python sources
       become: true
-      become_user: "{{ _paperless_ngx_untar_username }}"
       ansible.builtin.unarchive:
         src: "{{ paperless_ngx_python_release_url }}"
         remote_src: true
         dest: "{{ _python_archive_dir.path }}"
         extra_opts: [--strip-components=1]
+        owner: "{{ _paperless_ngx_untar_username }}"
       register: _download_and_unarchive_python
       until:
         - "not 'urlopen error' in _download_and_unarchive_python.msg | default('')"

--- a/tasks/paperless_ngx/release_files.yml
+++ b/tasks/paperless_ngx/release_files.yml
@@ -41,7 +41,7 @@
         state: directory
         owner: "{{ paperless_ngx_system_user }}"
         group: "{{ paperless_ngx_system_group }}"
-        mode: "750"
+        mode: "755"
 
     - name: Create target temporary directory
       become: true

--- a/tasks/paperless_ngx/release_files.yml
+++ b/tasks/paperless_ngx/release_files.yml
@@ -60,14 +60,20 @@
       {{ _install_tempdir_state.files[0].path }}
       {%- endif -%}
 
+- name: Pepare permissions of tmp dir for untaring paperless-ngx sources
+  ansible.builtin.file:
+    state: directory
+    owner: 1000
+    group: 1000
+    path: "{{ _install_tempdir }}"
+
 - name: Download and extract paperless-ngx
   become: true
+  become_user: "{{ _paperless_ngx_untar_username }}"
   ansible.builtin.unarchive:
     src: "{{ _release__download_url }}"
     remote_src: true
     dest: "{{ _install_tempdir }}"
-    owner: "{{ paperless_ngx_system_user }}"
-    group: "{{ paperless_ngx_system_group }}"
   register: _download_and_unarchive_pngx
   until:
     - "not 'urlopen error' in _download_and_unarchive_pngx.msg | default('')"
@@ -80,8 +86,8 @@
   ansible.builtin.command:
     cmd: "{{ item }}"
   with_items:
-    - find {{ _install_tempdir }} -type d -exec chmod -c 0750 {} ;
-    - find {{ _install_tempdir }} -type f -exec chmod -c 0640 {} ;
+    - find {{ _install_tempdir }} -type d -exec chmod -c 0750 {} \; -exec chown {{ paperless_ngx_system_user }}:{{ paperless_ngx_system_group }} {} \;
+    - find {{ _install_tempdir }} -type f -exec chmod -c 0640 {} \; -exec chown {{ paperless_ngx_system_user }}:{{ paperless_ngx_system_group }} {} \;
   register: _set_temp_install_permissions
   changed_when:
     - 'not _set_temp_install_permissions.stdout == ""'

--- a/tasks/paperless_ngx/release_files.yml
+++ b/tasks/paperless_ngx/release_files.yml
@@ -69,11 +69,11 @@
 
 - name: Download and extract paperless-ngx
   become: true
-  become_user: "{{ _paperless_ngx_untar_username }}"
   ansible.builtin.unarchive:
     src: "{{ _release__download_url }}"
     remote_src: true
     dest: "{{ _install_tempdir }}"
+    owner: "{{ _paperless_ngx_untar_username }}"
   register: _download_and_unarchive_pngx
   until:
     - "not 'urlopen error' in _download_and_unarchive_pngx.msg | default('')"

--- a/tasks/preparation/platform.yml
+++ b/tasks/preparation/platform.yml
@@ -22,7 +22,7 @@
 
     - name: Set fact username for user with id 1000
       ansible.builtin.set_fact:
-        _paperless_ngx_untar_username: "{{ ( _getent_query_result['ansible_facts']['getent_passwd'] | dict2items | selectattr('value.2', 'equalto', '1000') )[0].value[3] }}"
+        _paperless_ngx_untar_username: "{{ ( _getent_query_result['ansible_facts']['getent_passwd'] | dict2items | selectattr('value.2', 'equalto', '1000') )[0].key }}"
   when: (paperless_ngx_conf_usermap_uid is undefined) or paperless_ngx_conf_usermap_uid != "1000"
 
 - name: Set fact username for user with id 1000

--- a/tasks/preparation/platform.yml
+++ b/tasks/preparation/platform.yml
@@ -11,6 +11,25 @@
     fail_msg: "This role only works with systemd"
     success_msg: "systemd found"
 
+- name: Determine user name with id 1000 as become-user for unarchive tasks
+  block:
+    - name: Query passwd database for user with id 1000
+      ansible.builtin.getent:
+        database: passwd
+        key: 1000
+        split: ':'
+      register: _getent_query_result
+
+    - name: Set fact username for user with id 1000
+      ansible.builtin.set_fact:
+        _paperless_ngx_untar_username: "{{ ( _getent_query_result['ansible_facts']['getent_passwd'] | dict2items | selectattr('value.2', 'equalto', '1000') )[0].value[3] }}"
+  when: (paperless_ngx_conf_usermap_uid is undefined) or paperless_ngx_conf_usermap_uid != "1000"
+
+- name: Set fact username for user with id 1000
+  ansible.builtin.set_fact:
+    _paperless_ngx_untar_username: "{{ paperless_ngx_system_user }}"
+  when: (paperless_ngx_conf_usermap_uid is defined) and paperless_ngx_conf_usermap_uid == "1000"
+
 - name: Compare versions of installed ansible and required ansible
   ansible.builtin.assert:
     that: "ansible_version.full is version_compare(ansible_version_minimum, '>=')"


### PR DESCRIPTION
Refers to issue #239. If the `paperless_ngx_conf_usermap_uid` variable is set to an id different from 1000, the unarchive fails to unpack files and change their ownership. This seems to be because the user unpacking the archive is different from the one owning the files.

This PR adds a lookup step to find out the correct user name with `id == 1000` in cause `paperless_ngx_conf_usermap_uid != 1000`. The user name stored in the variable `_paperless_ngx_untar_username` will then later be used as the `become_user` in the unarchive step.

Note that with this solution
- if there's no user with id 1000 yet
- and `paperless_ngx_conf_usermap_uid` is not defined
the lookup step will fail even though the user might perchance be created with the id 1000.

In order to prevent this one might to either have to move the system user creation step to an earlier stage or make `paperless_ngx_conf_usermap_uid` mandatory. I was not sure if it was okay to go down any of these routes.
