### PR TITLE
Prevent recursive variable expansion for `paperless_ngx_conf_filename_format`

### DIFF
--- a/tasks/paperless_ngx/configuration.yml
+++ b/tasks/paperless_ngx/configuration.yml
@@ -260,7 +260,7 @@
     - pngx_var: PAPERLESS_STATICDIR
       role_var: "{{ paperless_ngx_conf_staticdir }}"
     - pngx_var: PAPERLESS_FILENAME_FORMAT
-      role_var: "{{ paperless_ngx_conf_filename_format }}"
+      role_var: "{{ '{{' }} paperless_ngx_conf_filename_format {{ '}}' }}"
     - pngx_var: PAPERLESS_FILENAME_FORMAT_REMOVE_NONE
       role_var: "{{ paperless_ngx_conf_filename_format_remove_none }}"
     - pngx_var: PAPERLESS_LOGGING_DIR


### PR DESCRIPTION
 It seems that even when wrapped between `{% raw %}...{% endraw %}` the `ansible.builtin.lineinfile` task interprets the paperless-ngx specific placeholde syntax as Jinja variable expressions and tries to expand them. This causes trouble when using the paperless-ngx specific text template syntax in `paperless_ngx_conf_filename_format` as ansible and paperless have identical syntaxes in this regard. 

This recursive variable expansion can be prevented by escaping the loop item which renders the line for the filename format. (For a more details, see #241.) Again I'm not sure if this is the intended way. But if so, I am happy to assist.