### PR TITLE
fix: execute version number check also in check mode

### DIFF
--- a/tasks/preparation/pngx_release.yml
+++ b/tasks/preparation/pngx_release.yml
@@ -50,7 +50,6 @@
       retries: 5
       check_mode: false
 
-
 - name: Check for existing paperless-ngx version file
   become: true
   ansible.builtin.stat:
@@ -68,7 +67,7 @@
       changed_when: _paperless_ngx_version_installed_object.stdout != paperless_ngx_version | string
       # failed_when: false
       # ignore_errors: true
-      when: not ansible_check_mode | bool
+      check_mode: false
 
     - name: Set version of current installation as variable
       ansible.builtin.set_fact:


### PR DESCRIPTION
Enable version reading in check mode by:
- Adding `check_mode: false` to cat command tasks
- Removing conditional `when: not ansible_check_mode | bool` blocks
- Allows version retrieval even during playbook validation with `--check`

### Why?

The cat command needs to execute in check mode to read the current version from the paperless-ngx installation, otherwise version validation fails during dry-run previews.
