### PR TITLE
fix: remove paperless_ngx_conf_filename_format quoting, avoid recursion

### DIFF
--- a/tasks/paperless_ngx/configuration.yml
+++ b/tasks/paperless_ngx/configuration.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set fact paperless_ngx_conf_filename_format to avoid recursion
+  ansible.builtin.set_fact:
+    paperless_ngx_conf_filename_format: "{{ paperless_ngx_conf_filename_format }}"
+
 - name: Write the paperless-ngx config file
   become: true
   ansible.builtin.lineinfile:
@@ -290,7 +294,7 @@
     - pngx_var: PAPERLESS_STATICDIR
       role_var: "{{ paperless_ngx_conf_staticdir }}"
     - pngx_var: PAPERLESS_FILENAME_FORMAT
-      role_var: "{{ '{{' }} paperless_ngx_conf_filename_format {{ '}}' }}"
+      role_var: "{{ paperless_ngx_conf_filename_format }}"
     - pngx_var: PAPERLESS_FILENAME_FORMAT_REMOVE_NONE
       role_var: "{{ paperless_ngx_conf_filename_format_remove_none }}"
     - pngx_var: PAPERLESS_LOGGING_DIR


### PR DESCRIPTION
Quoting of the variable _paperless_ngx_conf_filename_format_ during the writing of the paperless-ngx configuration file resulted in the variable name being written to the configuration file.

The recursion of variable evaluation is avoided by setting a fact. The idea was inspired by this: [Self-reference for Ansible variables](https://medium.com/opsops/self-reference-for-ansible-variables-886145e122f1)

This is a correction of #250.