### PR TITLE
fix: stop writing literal `{{ paperless_ngx_conf_filename_format }}` to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Installs and configures paperless-ngx EDMS.
 	* 3.3. [Generated password](#Generatedpassword)
 	* 3.4. [Separation of static (~ installation) and dynamic (~ runtime) data](#Separationofstaticinstallationanddynamicruntimedata)
 	* 3.5. [PostgreSQL usage](#PostgreSQLusage)
+	* 3.6. [Filename format](#Filenameformat)
 * 4. [Dependencies](#Dependencies)
 * 5. [Example Playbooks](#ExamplePlaybooks)
 * 6. [Contributing](#Contributing)
@@ -179,7 +180,7 @@ To save reading space a few abbreviations are used in the table down below:
 | `paperless_ngx_conf_enable_update_check` |  | Y | Y | Will be removed in the future |   |
 | `paperless_ngx_conf_filename_date_order` | "" | Y | Y |   |   |
 | `paperless_ngx_conf_filename_format_remove_none` | false | Y | Y |   |   |
-| `paperless_ngx_conf_filename_format` | "" | Y | Y | If you want to use paperless variables, wrap them like so: {% raw %}{{ created_year_short }}-{{ correspondent }}-{{ title }}{% endraw %} |   |
+| `paperless_ngx_conf_filename_format` | "" | Y | Y | Omitted from the config file when empty. Paperless placeholders must use YAML `!unsafe` (see [filename format](#Filenameformat)) |   |
 | `paperless_ngx_conf_force_script_name` | "" | Y | Y |   |   |
 | `paperless_ngx_conf_gmail_oauth_client_id` | None | Y | Y |   | 2.12 |
 | `paperless_ngx_conf_gmail_oauth_client_secret` | None | Y | Y |   | 2.12 |
@@ -284,6 +285,14 @@ This role checks that you do not set one of the data dirs (like consumption etc.
 
 ###  3.5. <a name='PostgreSQLusage'></a>PostgreSQL usage
 If you want to use Paperless-ngx together with PostgreSQL a running instance of PostgreSQL is required. This role does not automatically install such a database instance for you. However, here is you can read an example how to set up such an instance from scretch: [Link to example playbook](docs/POSTGRESQL.md)
+
+###  3.6. <a name='Filenameformat'></a>Filename format
+
+`paperless_ngx_conf_filename_format` is written to `PAPERLESS_FILENAME_FORMAT` only when it is non-empty. Paperless filename templates use `{{ … }}`, which Ansible would otherwise expand as its own variable. Tag the value as unsafe so it is copied into `/etc/paperless.conf` unchanged:
+
+```yaml
+paperless_ngx_conf_filename_format: !unsafe "{{ created_year_short }}-{{ correspondent }}-{{ title }}"
+```
 
 ##  4. <a name='Dependencies'></a>Dependencies
 

--- a/molecule/alternative_installation/converge.yml
+++ b/molecule/alternative_installation/converge.yml
@@ -19,5 +19,4 @@
         paperless_ngx_system_user_additional_groups:
           - root
         paperless_ngx_conf_enable_nltk: 1
-        # PR 242
-        paperless_ngx_conf_filename_format: '{% raw %}{{ created_year_short }}-{{ correspondent }}-{{ title }}{% endraw %}'
+        paperless_ngx_conf_filename_format: !unsafe "{{ created_year_short }}-{{ correspondent }}-{{ title }}"

--- a/molecule/alternative_installation/roles/test_alternative_installation/tasks/test_settings.yml
+++ b/molecule/alternative_installation/roles/test_alternative_installation/tasks/test_settings.yml
@@ -22,3 +22,25 @@
       loop:
         - setting_key: CONSUMER_IGNORE_PATTERNS
           expected_value: '\[.*?\]'
+
+- name: Check PAPERLESS_FILENAME_FORMAT in paperless.conf
+  vars:
+    expected_filename_format_line: !unsafe "PAPERLESS_FILENAME_FORMAT={{ created_year_short }}-{{ correspondent }}-{{ title }}"
+  block:
+    - name: Read paperless config file
+      become: true
+      ansible.builtin.slurp:
+        src: "{{ paperless_ngx_config_file }}"
+      register: test_alternative_installation__paperless_conf
+
+    - name: Assert PAPERLESS_FILENAME_FORMAT writes Paperless placeholders
+      ansible.builtin.assert:
+        that:
+          - expected_filename_format_line in conf_lines
+          - "'paperless_ngx_conf_filename_format' not in conf_text"
+        fail_msg: >-
+          Expected {{ expected_filename_format_line }} in {{ paperless_ngx_config_file }}.
+          Found filename-format lines: {{ conf_lines | select('match', '^#?PAPERLESS_FILENAME_FORMAT=') | list }}
+      vars:
+        conf_text: "{{ test_alternative_installation__paperless_conf.content | b64decode }}"
+        conf_lines: "{{ conf_text.splitlines() }}"

--- a/molecule/default_verification.yml
+++ b/molecule/default_verification.yml
@@ -3,6 +3,24 @@
   ansible.builtin.include_vars:
     file: ../defaults/main.yml
 
+- name: Read paperless config file
+  become: true
+  ansible.builtin.slurp:
+    src: /etc/paperless.conf
+  register: _paperless_conf
+
+- name: Assert PAPERLESS_FILENAME_FORMAT is omitted when unset
+  ansible.builtin.assert:
+    that:
+      - filename_format_lines | length == 0
+      - "'paperless_ngx_conf_filename_format' not in conf_text"
+    fail_msg: >-
+      PAPERLESS_FILENAME_FORMAT must not be written when paperless_ngx_conf_filename_format is unset.
+      Found: {{ filename_format_lines }}
+  vars:
+    conf_text: "{{ _paperless_conf.content | b64decode }}"
+    filename_format_lines: "{{ conf_text.splitlines() | select('match', '^#?PAPERLESS_FILENAME_FORMAT=') | list }}"
+
 - name: Check if webserver is up
   ansible.builtin.uri:
     url: http://localhost:{{ paperless_ngx_conf_port }}

--- a/tasks/paperless_ngx/configuration.yml
+++ b/tasks/paperless_ngx/configuration.yml
@@ -290,7 +290,8 @@
     - pngx_var: PAPERLESS_STATICDIR
       role_var: "{{ paperless_ngx_conf_staticdir }}"
     - pngx_var: PAPERLESS_FILENAME_FORMAT
-      role_var: "{{ '{{' }} paperless_ngx_conf_filename_format {{ '}}' }}"
+      role_var: "{{ paperless_ngx_conf_filename_format }}"
+      condition: "{{ paperless_ngx_conf_filename_format | default('') | length > 0 }}"
     - pngx_var: PAPERLESS_FILENAME_FORMAT_REMOVE_NONE
       role_var: "{{ paperless_ngx_conf_filename_format_remove_none }}"
     - pngx_var: PAPERLESS_LOGGING_DIR


### PR DESCRIPTION
Fixes #241 (regression introduced by #250).

## Summary

Since 4.1.0 (#250), `PAPERLESS_FILENAME_FORMAT` is always written to `/etc/paperless.conf` as the literal string `{{ paperless_ngx_conf_filename_format }}` instead of the role variable’s value. Paperless then logs undefined-template warnings on every document. So, the Paperless still runs, that's why the bug was not detected earlier.

This PR:

- Restores direct interpolation: `role_var: "{{ paperless_ngx_conf_filename_format }}"`
- Skips writing `PAPERLESS_FILENAME_FORMAT` when the variable is unset/empty (the default)
- Documents that Paperless placeholders must be passed with YAML `!unsafe` (same pattern as `paperless_ngx_conf_consumer_tag_barcode_mapping`)
- Adds molecule assertions on `/etc/paperless.conf` so this cannot regress silently again

## Background

#241 reported that Paperless filename templates (`{{ created_year_short }}-{{ title }}`, etc.) are interpreted by Ansible when written via `lineinfile`. #242 proposed escaping the loop entry; #250 merged that approach.

The #250 fix avoided Ansible double-templating by never substituting the role variable at all. That stopped playbook failures for custom formats, but introduced a worse default-install bug: every deployment writes a bogus config line, and the existing `when: item.role_var not in (None, omit)` guard no longer skips the entry because `role_var` is always a non-empty string.

## Changes

| Area | Change |
|---|---|
| `tasks/paperless_ngx/configuration.yml` | Revert #250 concat; add `condition` to skip empty values |
| `README.md` | New “Filename format” section; variable table points to `!unsafe` usage |
| `molecule/alternative_installation/converge.yml` | Use `!unsafe` instead of `{% raw %}` |
| `molecule/alternative_installation/.../test_settings.yml` | Check that correct line is written |
| `molecule/default_verification.yml` | Check that configuration line is omitted when unset |

### User-facing example

```yaml
paperless_ngx_conf_filename_format: !unsafe "{{ created_year_short }}-{{ correspondent }}-{{ title }}"