### PR TITLE
ci: replace archived pr title checker with action-semantic-pull-request

### DIFF
--- a/.github/workflows/pr_labeling.yml
+++ b/.github/workflows/pr_labeling.yml
@@ -15,12 +15,10 @@ jobs:
   pr_title_check:
     name: Check the PR title to be compliant with conventional commits
     permissions:
-      statuses: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
-        with:
-          preset: conventional-changelog-conventionalcommits@5.0.0
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The `aslafy-z/conventional-pr-title-action` repository has been archived and recommends migrating to [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).

This replaces the deprecated action in the PR labeling workflow, updates job permissions from `statuses: write` to `pull-requests: read` (minimal required permissions for amannn-authored runner).

Also, it pins the new action to a full commit SHA (`v6.1.1`). Pinning to a full commit SHA is considered a [best practice](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) by Github Actions team. But pinning to a full commit SHA doesn't mean that Dependabot won't be able to auto-update this action anymore. Since, I left the comment with exact version - it will catch it and will auto-create the PRs to update action. And still will use the same SHA pinning schema.

Pinning a commit protects against supply chain attacks (like SHA-HULUD), that could steal your Github token. And upload malicious code to your repo.

Conventional-commit title validation and downstream auto-labeling behavior remain unchanged.